### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
   package-test:
     name: Test package build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: test
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/nordstad/PinViz/security/code-scanning/1](https://github.com/nordstad/PinViz/security/code-scanning/1)

To fix the problem, add a `permissions` block to the `package-test` job. Analyze which permissions are actually needed: since this job only performs code checkout, builds the package, checks contents, and uploads artifacts—not touching PRs, contents, or checks—it needs no write access. As a minimal starting point and continuing least privilege, set `contents: read`. To implement the change, edit the `.github/workflows/ci.yml` file, and add the following snippet immediately under `runs-on: ubuntu-latest` in the `package-test` job (around line 66). No new methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
