### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
     name: Verify Examples
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     needs: test
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/nordstad/PinViz/security/code-scanning/2](https://github.com/nordstad/PinViz/security/code-scanning/2)

To fix the problem, add a `permissions` block to the `verify-examples` job, limiting the GITHUB_TOKEN scope to the minimum required. Since this job does not appear to perform any operations requiring write permissions or interactions with GitHub APIs (it only checks out code and runs scripts), it is safe to set `permissions: contents: read`. The permissions block should be indented properly under the `verify-examples` job definition after the runner and timeout fields (similar to how it appears in other jobs). No additional methods, imports, or other changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
