### PR TITLE
Improve CLI help formatting and consistency

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -16,8 +16,6 @@ Generate a diagram from a YAML or JSON configuration file:
 
 ```bash
 pinviz render CONFIG_FILE [-o OUTPUT_FILE]
-# Or simply:
-pinviz CONFIG_FILE [-o OUTPUT_FILE]
 ```
 
 **Arguments:**
@@ -35,7 +33,7 @@ pinviz render my-diagram.yaml
 pinviz render my-diagram.yaml -o output/wiring.svg
 
 # Works with JSON too
-pinviz my-diagram.json -o output.svg
+pinviz render my-diagram.json -o output.svg
 ```
 
 ### Generate Built-in Examples

--- a/src/pinviz/mcp/server.py
+++ b/src/pinviz/mcp/server.py
@@ -150,7 +150,7 @@ def generate_diagram(prompt: str, output_format: str = "yaml", title: str | None
         When output_format is 'yaml':
         - The response contains a 'yaml_content' field with the complete PinViz YAML configuration
         - This YAML should be saved to a file (e.g., diagram.yaml) and rendered with:
-          pinviz diagram.yaml -o output.svg
+          pinviz render diagram.yaml -o output.svg
         - DO NOT modify or reconstruct the YAML - use the 'yaml_content' field exactly as provided
         - The YAML includes full device pin definitions required by the pinviz CLI
     """
@@ -261,7 +261,7 @@ devices:
             result["message"] = (
                 "Complete PinViz YAML configuration generated. "
                 "Save the 'yaml_content' field to a file and render with: "
-                "pinviz <file>.yaml -o output.svg"
+                "pinviz render <file>.yaml -o output.svg"
             )
 
         elif output_format == "json":


### PR DESCRIPTION
## Summary

This PR improves the CLI help output to be more professional and consistent, following best practices from tools like AWS CLI.

## Changes Made

### 1. CLI Help Output (`src/pinviz/cli.py`)
- ✅ Removed `{render,example,list}` from command display using `metavar="COMMAND"`
- ✅ Changed "Positional Arguments" to "Commands:" section  
- ✅ Formatted examples section with proper line breaks (no more wrapping)
- ✅ Added default values to all options (`--gpio`/`--no-gpio`)
- ✅ Made `--gpio`/`--no-gpio` mutually exclusive groups
- ✅ Used better metavar names: `CONFIG_FILE`, `PATH`, `NAME`
- ✅ Added descriptions to each subcommand
- ✅ Created `CustomHelpFormatter` to preserve examples formatting

### 2. MCP Server (`src/pinviz/mcp/server.py`)
- ✅ Updated documentation strings to use new CLI format
- ✅ Changed: `pinviz diagram.yaml` → `pinviz render diagram.yaml`

### 3. Documentation (`docs/guide/cli.md`)
- ✅ Removed alternative format suggestion
- ✅ Updated all examples to use explicit "render" command
- ✅ Ensured consistency across all documentation

## Before

\`\`\`
Usage: pinviz [-h] [-v] {render,example,list} ...

Positional Arguments:
  {render,example,list}
    render       Render a diagram from a configuration file
    example      Generate a built-in example diagram
    list         List available board and device templates

Examples: # Generate diagram from YAML config pinviz diagram.yaml # Specify output path pinviz diagram.yaml -o output/wiring.svg # Use a built-in
example pinviz example bh1750 For more information, visit: https://github.com/nordstad/PinViz
\`\`\`

## After

\`\`\`
Usage: pinviz [-h] [-v] COMMAND ...

Commands:
  COMMAND
    render       Render a diagram from a configuration file
    example      Generate a built-in example diagram
    list         List available board and device templates

Examples:
  pinviz render diagram.yaml                     # Generate diagram from YAML config
  pinviz render diagram.yaml -o out/wiring.svg   # Specify output path
  pinviz example bh1750                          # Use a built-in example
  pinviz list                                     # List available templates

For more information, visit: https://github.com/nordstad/PinViz
\`\`\`

## Testing

- ✅ All 23 CLI tests pass
- ✅ All 5 MCP tests pass  
- ✅ Code validated with ruff
- ✅ No breaking changes to functionality
- ✅ All documentation updated

## Type of Change

- [x] Enhancement (non-breaking change that improves existing functionality)
- [x] Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)