### PR TITLE
Fix docstring formatting: Change 'Example:' to 'Examples:'

### DIFF
--- a/src/pinviz/boards.py
+++ b/src/pinviz/boards.py
@@ -154,7 +154,7 @@ def raspberry_pi_zero_2w() -> Board:
     Returns:
         Board: Configured Raspberry Pi Zero 2 W board
 
-    Example:
+    Examples:
         >>> from pinviz import boards
         >>> board = boards.raspberry_pi_zero_2w()
         >>> print(board.name)
@@ -267,7 +267,7 @@ def raspberry_pi() -> Board:
     Returns:
         Board: Configured Raspberry Pi board
 
-    Example:
+    Examples:
         >>> from pinviz import boards
         >>> board = boards.raspberry_pi()
         >>> print(board.name)

--- a/src/pinviz/config_loader.py
+++ b/src/pinviz/config_loader.py
@@ -29,7 +29,7 @@ class ConfigLoader:
     Handles predefined device types from the device registry and custom
     device definitions with automatic wire color assignment.
 
-    Example:
+    Examples:
         >>> loader = ConfigLoader()
         >>> diagram = loader.load_from_file("config.yaml")
         >>> print(diagram.title)
@@ -192,7 +192,7 @@ class ConfigLoader:
         Raises:
             ValueError: If device configuration is invalid or incomplete
 
-        Example:
+        Examples:
             >>> # Predefined device
             >>> config = {"type": "bh1750", "name": "Light Sensor"}
             >>> device = loader._load_device(config)
@@ -263,7 +263,7 @@ class ConfigLoader:
         Returns:
             Device object
 
-        Example:
+        Examples:
             >>> config = {
             ...     "name": "Custom Module",
             ...     "width": 100.0,
@@ -333,7 +333,7 @@ class ConfigLoader:
         Returns:
             Connection object
 
-        Example:
+        Examples:
             >>> config = {
             ...     "board_pin": 11,
             ...     "device": "LED",

--- a/src/pinviz/model.py
+++ b/src/pinviz/model.py
@@ -214,7 +214,7 @@ class Board:
         Returns:
             HeaderPin if found, None otherwise
 
-        Example:
+        Examples:
             >>> board = boards.raspberry_pi_5()
             >>> pin = board.get_pin_by_number(1)
             >>> print(pin.name)
@@ -234,7 +234,7 @@ class Board:
         Returns:
             HeaderPin if found, None otherwise
 
-        Example:
+        Examples:
             >>> board = boards.raspberry_pi_5()
             >>> pin = board.get_pin_by_bcm(2)
             >>> print(f"{pin.name} is on physical pin {pin.number}")
@@ -252,7 +252,7 @@ class Board:
         Returns:
             HeaderPin if found, None otherwise
 
-        Example:
+        Examples:
             >>> board = boards.raspberry_pi_5()
             >>> pin = board.get_pin_by_name("GPIO2")
             >>> print(f"Pin {pin.number} - {pin.name}")
@@ -315,7 +315,7 @@ class Device:
         Returns:
             DevicePin if found, None otherwise
 
-        Example:
+        Examples:
             >>> sensor = devices.bh1750_light_sensor()
             >>> vcc_pin = sensor.get_pin_by_name("VCC")
             >>> print(vcc_pin.role)
@@ -397,7 +397,7 @@ class Connection:
         style: Wire routing style (orthogonal, curved, or mixed)
         components: List of inline components on this wire (resistors, capacitors, etc.)
 
-    Example:
+    Examples:
         >>> # Simple connection with auto-assigned color
         >>> conn = Connection(1, "Sensor", "VCC")
         >>>
@@ -439,7 +439,7 @@ class Diagram:
         canvas_width: Canvas width in SVG units (auto-calculated by layout engine)
         canvas_height: Canvas height in SVG units (auto-calculated by layout engine)
 
-    Example:
+    Examples:
         >>> from pinviz import boards, devices, Connection, Diagram, SVGRenderer
         >>>
         >>> # Create diagram

--- a/src/pinviz/render_svg.py
+++ b/src/pinviz/render_svg.py
@@ -26,7 +26,7 @@ class SVGRenderer:
         - Optional GPIO reference diagram
         - Automatic layout via LayoutEngine
 
-    Example:
+    Examples:
         >>> from pinviz import boards, devices, Connection, Diagram, SVGRenderer
         >>>
         >>> diagram = Diagram(


### PR DESCRIPTION
## Summary
Fixes code block formatting issues in the API documentation by updating docstring section headers from `Example:` (singular) to `Examples:` (plural).

## Problem
The mkdocs API documentation was not properly rendering code examples - they were appearing as plain text blockquotes instead of formatted code blocks with syntax highlighting. This affected the documentation at https://nordstad.github.io/PinViz/api/boards/ and other API reference pages.

## Root Cause
mkdocstrings (the plugin that generates API documentation from docstrings) requires Google-style docstring sections to use `Examples:` (plural) for proper recognition. When `Example:` (singular) was used, the parser didn't recognize it as a special section and rendered it as plain text.

## Changes
Updated 13 docstring sections across 4 files:
- **boards.py** (2 instances): `raspberry_pi()`, `raspberry_pi_zero_2w()`
- **config_loader.py** (4 instances): Class docstring and 3 private methods
- **model.py** (6 instances): Board and Device pin lookup methods, Connection and Diagram class docstrings
- **render_svg.py** (1 instance): SVGRenderer class docstring

## Results
- ✅ Examples sections now have clear section headings
- ✅ Code blocks properly formatted with syntax highlighting
- ✅ Python prompt (`>>>`) and output lines clearly distinguished
- ✅ All ruff checks pass
- ✅ Documentation builds successfully without errors

## Test Plan
- [x] Run `uv run mkdocs build` - builds successfully
- [x] Verify HTML output contains properly formatted code blocks
- [x] Run `uv run ruff check` - all checks pass
- [x] Run `uv run ruff format` - no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)