### PR TITLE
Improve wire connections to device pins

### DIFF
--- a/images/bh1750.svg
+++ b/images/bh1750.svg
@@ -1018,45 +1018,50 @@
 <text x="227.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">39</text>
 <circle cx="239.1" cy="324.2" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
 <text x="239.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">40</text>
-<path d="M 227.10,108.20 C 243.40,89.85 333.49,87.12 455.00,94.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,108.20 C 243.40,89.85 333.49,87.12 455.00,94.00" stroke="#00FF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,108.20 C 243.40,89.85 328.99,87.12 440.00,94.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,108.20 C 243.40,89.85 328.99,87.12 440.00,94.00" stroke="#00FF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="108.2" r="4" fill="white" />
 <circle cx="227.1" cy="108.2" r="3" fill="#00FF00" />
-<circle cx="455.0" cy="94.0" r="4" fill="white" />
-<circle cx="455.0" cy="94.0" r="3" fill="#00FF00" />
-<path d="M 227.10,120.20 C 248.20,168.27 344.69,104.03 455.00,86.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,120.20 C 248.20,168.27 344.69,104.03 455.00,86.00" stroke="#0000FF" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,120.20 C 248.20,168.27 340.19,104.03 440.00,86.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,120.20 C 248.20,168.27 340.19,104.03 440.00,86.00" stroke="#0000FF" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="120.2" r="4" fill="white" />
 <circle cx="227.1" cy="120.2" r="3" fill="#0000FF" />
-<circle cx="455.0" cy="86.0" r="4" fill="white" />
-<circle cx="455.0" cy="86.0" r="3" fill="#0000FF" />
-<path d="M 227.10,96.20 C 241.00,50.33 327.89,52.80 455.00,70.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,96.20 C 241.00,50.33 327.89,52.80 455.00,70.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,96.20 C 241.00,50.33 323.39,52.80 440.00,70.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,96.20 C 241.00,50.33 323.39,52.80 440.00,70.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="96.2" r="4" fill="white" />
 <circle cx="227.1" cy="96.2" r="3" fill="#FF8C00" />
-<circle cx="455.0" cy="70.0" r="4" fill="white" />
-<circle cx="455.0" cy="70.0" r="3" fill="#FF8C00" />
-<path d="M 239.10,120.20 C 254.20,136.34 339.09,84.05 455.00,78.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,120.20 C 254.20,136.34 339.09,84.05 455.00,78.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,120.20 C 254.20,136.34 334.59,84.05 440.00,78.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,120.20 C 254.20,136.34 334.59,84.05 440.00,78.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="120.2" r="4" fill="white" />
 <circle cx="239.1" cy="120.2" r="3" fill="#000000" />
-<circle cx="455.0" cy="78.0" r="4" fill="white" />
-<circle cx="455.0" cy="78.0" r="3" fill="#000000" />
 <text x="485.0" y="55.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">BH1750</text>
 <rect x="450.0" y="60.0" width="70.0" height="60.0" rx="5" ry="5" fill="#4A90E2" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="70.0" r="3" fill="#FFD700" stroke="#333" />
+<path d="M 440.00,94.00 L 457.00,94.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,94.00 L 457.00,94.00" stroke="#00FF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,86.00 L 457.00,86.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,86.00 L 457.00,86.00" stroke="#0000FF" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,70.00 L 457.00,70.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,70.00 L 457.00,70.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,78.00 L 457.00,78.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,78.00 L 457.00,78.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<circle cx="455.0" cy="70.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="70.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="65.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="72.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
-<circle cx="455.0" cy="78.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="78.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="78.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="73.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="80.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
-<circle cx="455.0" cy="86.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="86.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="86.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="81.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="88.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SCL</text>
-<circle cx="455.0" cy="94.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="94.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="94.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="89.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="96.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SDA</text>
-<circle cx="455.0" cy="102.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="102.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="102.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="97.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="104.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">ADDR</text>
 </svg>

--- a/images/bh1750_ir_led.svg
+++ b/images/bh1750_ir_led.svg
@@ -1018,74 +1018,82 @@
 <text x="227.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">39</text>
 <circle cx="239.1" cy="324.2" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
 <text x="239.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">40</text>
-<path d="M 227.10,156.20 C 254.20,160.89 358.69,166.76 455.00,165.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,156.20 C 254.20,160.89 358.69,166.76 455.00,165.00" stroke="#F44336" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,156.20 C 254.20,160.89 354.19,166.76 440.00,165.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,156.20 C 254.20,160.89 354.19,166.76 440.00,165.00" stroke="#F44336" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="156.2" r="4" fill="white" />
 <circle cx="227.1" cy="156.2" r="3" fill="#F44336" />
-<circle cx="455.0" cy="165.0" r="4" fill="white" />
-<circle cx="455.0" cy="165.0" r="3" fill="#F44336" />
-<path d="M 227.10,108.20 C 243.40,91.75 333.49,87.83 455.00,94.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,108.20 C 243.40,91.75 333.49,87.83 455.00,94.00" stroke="#4CAF50" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,108.20 C 243.40,91.66 328.99,87.80 440.00,94.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,108.20 C 243.40,91.66 328.99,87.80 440.00,94.00" stroke="#4CAF50" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="108.2" r="4" fill="white" />
 <circle cx="227.1" cy="108.2" r="3" fill="#4CAF50" />
-<circle cx="455.0" cy="94.0" r="4" fill="white" />
-<circle cx="455.0" cy="94.0" r="3" fill="#4CAF50" />
-<path d="M 227.10,120.20 C 245.80,131.75 339.09,90.33 455.00,86.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,120.20 C 245.80,131.75 339.09,90.33 455.00,86.00" stroke="#2196F3" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,120.20 C 245.80,131.67 334.59,90.30 440.00,86.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,120.20 C 245.80,131.67 334.59,90.30 440.00,86.00" stroke="#2196F3" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="120.2" r="4" fill="white" />
 <circle cx="227.1" cy="120.2" r="3" fill="#2196F3" />
-<circle cx="455.0" cy="86.0" r="4" fill="white" />
-<circle cx="455.0" cy="86.0" r="3" fill="#2196F3" />
-<path d="M 227.10,144.20 C 255.23,233.20 391.97,107.67 455.00,78.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,144.20 C 255.23,233.20 391.97,107.67 455.00,78.00" stroke="#FFEB3B" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,144.20 C 255.23,233.39 382.97,107.73 440.00,78.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,144.20 C 255.23,233.39 382.97,107.73 440.00,78.00" stroke="#FFEB3B" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="144.2" r="4" fill="white" />
 <circle cx="227.1" cy="144.2" r="3" fill="#FFEB3B" />
-<circle cx="455.0" cy="78.0" r="4" fill="white" />
-<circle cx="455.0" cy="78.0" r="3" fill="#FFEB3B" />
-<path d="M 227.10,96.20 C 241.00,21.53 327.89,42.00 455.00,70.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,96.20 C 241.00,21.53 327.89,42.00 455.00,70.00" stroke="#FF9800" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,96.20 C 241.00,21.53 323.39,42.00 440.00,70.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,96.20 C 241.00,21.53 323.39,42.00 440.00,70.00" stroke="#FF9800" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="96.2" r="4" fill="white" />
 <circle cx="227.1" cy="96.2" r="3" fill="#FF9800" />
-<circle cx="455.0" cy="70.0" r="4" fill="white" />
-<circle cx="455.0" cy="70.0" r="3" fill="#FF9800" />
-<path d="M 239.10,120.20 C 267.23,170.48 396.77,191.76 455.00,175.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,120.20 C 267.23,170.48 396.77,191.76 455.00,175.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,120.20 C 267.23,170.48 387.77,191.76 440.00,175.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,120.20 C 267.23,170.48 387.77,191.76 440.00,175.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="120.2" r="4" fill="white" />
 <circle cx="239.1" cy="120.2" r="3" fill="#000000" />
-<circle cx="455.0" cy="175.0" r="4" fill="white" />
-<circle cx="455.0" cy="175.0" r="3" fill="#000000" />
-<path d="M 239.10,96.20 C 264.03,41.15 393.57,136.65 455.00,155.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,96.20 C 264.03,41.15 393.57,136.65 455.00,155.00" stroke="#F44336" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,96.20 C 264.03,41.15 384.57,136.65 440.00,155.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,96.20 C 264.03,41.15 384.57,136.65 440.00,155.00" stroke="#F44336" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="96.2" r="4" fill="white" />
 <circle cx="239.1" cy="96.2" r="3" fill="#F44336" />
-<circle cx="455.0" cy="155.0" r="4" fill="white" />
-<circle cx="455.0" cy="155.0" r="3" fill="#F44336" />
 <text x="485.0" y="55.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">BH1750 Light Sensor</text>
 <rect x="450.0" y="60.0" width="70.0" height="60.0" rx="5" ry="5" fill="#4A90E2" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="70.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="65.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="72.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
-<circle cx="455.0" cy="78.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="73.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="80.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
-<circle cx="455.0" cy="86.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="81.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="88.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SCL</text>
-<circle cx="455.0" cy="94.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="89.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="96.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SDA</text>
-<circle cx="455.0" cy="102.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="97.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="104.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">ADDR</text>
 <text x="490.0" y="135.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">IR LED Ring</text>
 <rect x="450.0" y="140.0" width="80.0" height="50.0" rx="5" ry="5" fill="#E24A4A" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="155.0" r="3" fill="#FFD700" stroke="#333" />
+<path d="M 440.00,165.00 L 457.00,165.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,165.00 L 457.00,165.00" stroke="#F44336" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,94.00 L 457.00,94.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,94.00 L 457.00,94.00" stroke="#4CAF50" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,86.00 L 457.00,86.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,86.00 L 457.00,86.00" stroke="#2196F3" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,78.00 L 457.00,78.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,78.00 L 457.00,78.00" stroke="#FFEB3B" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,70.00 L 457.00,70.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,70.00 L 457.00,70.00" stroke="#FF9800" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,175.00 L 457.00,175.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,175.00 L 457.00,175.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,155.00 L 457.00,155.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,155.00 L 457.00,155.00" stroke="#F44336" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<circle cx="455.0" cy="70.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="70.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="65.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="72.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
+<circle cx="455.0" cy="78.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="78.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="73.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="80.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
+<circle cx="455.0" cy="86.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="86.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="81.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="88.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SCL</text>
+<circle cx="455.0" cy="94.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="94.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="89.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="96.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SDA</text>
+<circle cx="455.0" cy="102.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="102.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="97.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="104.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">ADDR</text>
+<circle cx="455.0" cy="155.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="155.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="150.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="157.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
-<circle cx="455.0" cy="165.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="165.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="165.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="160.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="167.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">CTRL</text>
-<circle cx="455.0" cy="175.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="175.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="175.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="170.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="177.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
 </svg>

--- a/images/ds18b20_temp.svg
+++ b/images/ds18b20_temp.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-     width="695.0" height="447.46" viewBox="0 0 695.0 447.46">
+     width="565.0" height="427.46" viewBox="0 0 565.0 427.46">
 <defs>
 </defs>
-<rect x="0" y="0" width="695.0" height="447.46" fill="white" />
-<text x="347.5" y="25" font-size="20" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">DS18B20 Waterproof Temperature Sensor</text>
+<rect x="0" y="0" width="565.0" height="427.46" fill="white" />
+<text x="282.5" y="25" font-size="20" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">DS18B20 Waterproof Temperature Sensor</text>
 <g transform="translate(40.0, 80.0)">
 <g>
 <g id="g477">
@@ -1018,41 +1018,44 @@
 <text x="227.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">39</text>
 <circle cx="239.1" cy="324.2" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
 <text x="239.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">40</text>
-<path d="M 227.10,144.20 C 253.63,177.50 390.37,103.10 455.00,92.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,144.20 C 253.63,177.50 390.37,103.10 455.00,92.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,144.20 C 253.63,177.50 381.37,103.10 440.00,92.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,144.20 C 253.63,177.50 381.37,103.10 440.00,92.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="144.2" r="4" fill="white" />
 <circle cx="227.1" cy="144.2" r="3" fill="#000000" />
-<circle cx="455.0" cy="92.0" r="4" fill="white" />
-<circle cx="455.0" cy="92.0" r="3" fill="#000000" />
-<path d="M 227.10,132.20 Q 250.43,132.20 295.22,115.75" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,132.20 Q 250.43,132.20 295.22,115.75" stroke="#FFFF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
-<g transform="translate(295.22372945036545, 115.75458813508595) rotate(-20.159200073190835)">
+<path d="M 227.10,132.20 Q 250.43,132.20 295.56,114.46" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,132.20 Q 250.43,132.20 295.56,114.46" stroke="#FFFF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<g transform="translate(295.56280269437144, 114.46266560781709) rotate(-21.454119608560777)">
 <rect x="-10.0" y="-3.0" width="20.0" height="6.0" fill="white" stroke="#FFFF00" stroke-width="2" />
 <path d="M-18.0,0 L-10.0,0" stroke="#FFFF00" stroke-width="2" />
 <path d="M10.0,0 L18.0,0" stroke="#FFFF00" stroke-width="2" />
 <text x="0" y="-8.0" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" fill="#333" font-weight="bold">4.7kΩ</text>
 </g>
-<path d="M 295.22,115.75 Q 387.17,82.00 455.00,82.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 295.22,115.75 Q 387.17,82.00 455.00,82.00" stroke="#FFFF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 295.56,114.46 C 378.17,82.00 440.00,82.00 457.00,82.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 295.56,114.46 C 378.17,82.00 440.00,82.00 457.00,82.00" stroke="#FFFF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="132.2" r="4" fill="white" />
 <circle cx="227.1" cy="132.2" r="3" fill="#FFFF00" />
-<circle cx="455.0" cy="82.0" r="4" fill="white" />
-<circle cx="455.0" cy="82.0" r="3" fill="#FFFF00" />
-<path d="M 227.10,96.20 C 242.20,66.60 330.69,60.90 455.00,72.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,96.20 C 242.20,66.60 330.69,60.90 455.00,72.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,96.20 C 242.20,66.60 326.19,60.90 440.00,72.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,96.20 C 242.20,66.60 326.19,60.90 440.00,72.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="96.2" r="4" fill="white" />
 <circle cx="227.1" cy="96.2" r="3" fill="#FF0000" />
-<circle cx="455.0" cy="72.0" r="4" fill="white" />
-<circle cx="455.0" cy="72.0" r="3" fill="#FF0000" />
 <text x="487.5" y="55.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">DS18B20</text>
 <rect x="450.0" y="60.0" width="75.0" height="45.0" rx="5" ry="5" fill="#F39C12" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="72.0" r="3" fill="#FFD700" stroke="#333" />
+<path d="M 440.00,92.00 L 457.00,92.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,92.00 L 457.00,92.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,82.00 L 457.00,82.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,82.00 L 457.00,82.00" stroke="#FFFF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,72.00 L 457.00,72.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,72.00 L 457.00,72.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<circle cx="455.0" cy="72.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="72.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="67.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="74.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
-<circle cx="455.0" cy="82.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="82.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="82.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="77.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="84.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">DATA</text>
-<circle cx="455.0" cy="92.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="92.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="92.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="87.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="94.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
 </svg>

--- a/images/i2c_spi.svg
+++ b/images/i2c_spi.svg
@@ -1018,121 +1018,134 @@
 <text x="227.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">39</text>
 <circle cx="239.1" cy="324.2" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
 <text x="239.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">40</text>
-<path d="M 227.10,156.20 C 258.43,96.32 395.17,215.04 455.00,235.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,156.20 C 258.43,96.32 395.17,215.04 455.00,235.00" stroke="#808080" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,156.20 C 258.43,97.04 386.17,215.28 440.00,235.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,156.20 C 258.43,97.04 386.17,215.28 440.00,235.00" stroke="#808080" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="156.2" r="4" fill="white" />
 <circle cx="227.1" cy="156.2" r="3" fill="#808080" />
-<circle cx="455.0" cy="235.0" r="4" fill="white" />
-<circle cx="455.0" cy="235.0" r="3" fill="#808080" />
-<path d="M 227.10,216.20 C 260.20,199.40 372.69,175.70 455.00,182.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,216.20 C 260.20,199.40 372.69,175.70 455.00,182.00" stroke="#FF69B4" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,216.20 C 260.20,199.24 368.19,175.64 440.00,182.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,216.20 C 260.20,199.24 368.19,175.64 440.00,182.00" stroke="#FF69B4" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="216.2" r="4" fill="white" />
 <circle cx="227.1" cy="216.2" r="3" fill="#FF69B4" />
-<circle cx="455.0" cy="182.0" r="4" fill="white" />
-<circle cx="455.0" cy="182.0" r="3" fill="#FF69B4" />
-<path d="M 227.10,204.20 C 257.80,252.64 367.09,192.17 455.00,174.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,204.20 C 257.80,252.64 367.09,192.17 455.00,174.00" stroke="#00CED1" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,204.20 C 257.80,252.64 362.59,192.17 440.00,174.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,204.20 C 257.80,252.64 362.59,192.17 440.00,174.00" stroke="#00CED1" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="204.2" r="4" fill="white" />
 <circle cx="227.1" cy="204.2" r="3" fill="#00CED1" />
-<circle cx="455.0" cy="174.0" r="4" fill="white" />
-<circle cx="455.0" cy="174.0" r="3" fill="#00CED1" />
-<path d="M 227.10,228.20 C 274.43,229.72 411.17,166.51 455.00,166.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,228.20 C 274.43,229.72 411.17,166.51 455.00,166.00" stroke="#FFD700" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,228.20 C 274.43,229.63 402.17,166.48 440.00,166.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,228.20 C 274.43,229.63 402.17,166.48 440.00,166.00" stroke="#FFD700" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="228.2" r="4" fill="white" />
 <circle cx="227.1" cy="228.2" r="3" fill="#FFD700" />
-<circle cx="455.0" cy="166.0" r="4" fill="white" />
-<circle cx="455.0" cy="166.0" r="3" fill="#FFD700" />
-<path d="M 227.10,192.20 C 253.00,192.52 355.89,150.12 455.00,150.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,192.20 C 253.00,192.52 355.89,150.12 455.00,150.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,192.20 C 253.00,192.32 351.39,150.05 440.00,150.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,192.20 C 253.00,192.32 351.39,150.05 440.00,150.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="192.2" r="4" fill="white" />
 <circle cx="227.1" cy="192.2" r="3" fill="#FF8C00" />
-<circle cx="455.0" cy="150.0" r="4" fill="white" />
-<circle cx="455.0" cy="150.0" r="3" fill="#FF8C00" />
-<path d="M 227.10,108.20 C 243.40,86.50 333.49,85.86 455.00,94.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,108.20 C 243.40,86.50 333.49,85.86 455.00,94.00" stroke="#00FF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,108.20 C 243.40,85.89 328.99,85.63 440.00,94.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,108.20 C 243.40,85.89 328.99,85.63 440.00,94.00" stroke="#00FF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="108.2" r="4" fill="white" />
 <circle cx="227.1" cy="108.2" r="3" fill="#00FF00" />
-<circle cx="455.0" cy="94.0" r="4" fill="white" />
-<circle cx="455.0" cy="94.0" r="3" fill="#00FF00" />
-<path d="M 227.10,120.20 C 245.80,132.31 339.09,90.54 455.00,86.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,120.20 C 245.80,132.31 339.09,90.54 455.00,86.00" stroke="#0000FF" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,120.20 C 245.80,132.18 334.59,90.49 440.00,86.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,120.20 C 245.80,132.18 334.59,90.49 440.00,86.00" stroke="#0000FF" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="120.2" r="4" fill="white" />
 <circle cx="227.1" cy="120.2" r="3" fill="#0000FF" />
-<circle cx="455.0" cy="86.0" r="4" fill="white" />
-<circle cx="455.0" cy="86.0" r="3" fill="#0000FF" />
-<path d="M 227.10,144.20 C 255.23,187.70 391.97,92.50 455.00,78.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,144.20 C 255.23,187.70 391.97,92.50 455.00,78.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,144.20 C 255.23,188.04 382.97,92.61 440.00,78.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,144.20 C 255.23,188.04 382.97,92.61 440.00,78.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="144.2" r="4" fill="white" />
 <circle cx="227.1" cy="144.2" r="3" fill="#000000" />
-<circle cx="455.0" cy="78.0" r="4" fill="white" />
-<circle cx="455.0" cy="78.0" r="3" fill="#000000" />
-<path d="M 227.10,96.20 C 241.00,50.33 327.89,52.80 455.00,70.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,96.20 C 241.00,50.33 327.89,52.80 455.00,70.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,96.20 C 241.00,50.33 323.39,52.80 440.00,70.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,96.20 C 241.00,50.33 323.39,52.80 440.00,70.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="96.2" r="4" fill="white" />
 <circle cx="227.1" cy="96.2" r="3" fill="#FF8C00" />
-<circle cx="455.0" cy="70.0" r="4" fill="white" />
-<circle cx="455.0" cy="70.0" r="3" fill="#FF8C00" />
-<path d="M 239.10,168.20 C 268.83,135.21 398.37,236.00 455.00,247.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,168.20 C 268.83,135.21 398.37,236.00 455.00,247.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,168.20 C 268.83,134.32 389.37,235.71 440.00,247.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,168.20 C 268.83,134.32 389.37,235.71 440.00,247.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="168.2" r="4" fill="white" />
 <circle cx="239.1" cy="168.2" r="3" fill="#000000" />
-<circle cx="455.0" cy="247.0" r="4" fill="white" />
-<circle cx="455.0" cy="247.0" r="3" fill="#000000" />
-<path d="M 239.10,228.20 C 273.40,266.47 383.89,204.35 455.00,190.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,228.20 C 273.40,266.47 383.89,204.35 455.00,190.00" stroke="#9370DB" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,228.20 C 273.40,267.69 379.39,204.81 440.00,190.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,228.20 C 273.40,267.69 379.39,204.81 440.00,190.00" stroke="#9370DB" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="228.2" r="4" fill="white" />
 <circle cx="239.1" cy="228.2" r="3" fill="#9370DB" />
-<circle cx="455.0" cy="190.0" r="4" fill="white" />
-<circle cx="455.0" cy="190.0" r="3" fill="#9370DB" />
-<path d="M 239.10,204.20 C 263.80,231.96 361.49,168.41 455.00,158.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,204.20 C 263.80,231.96 361.49,168.41 455.00,158.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,204.20 C 263.80,231.76 356.99,168.34 440.00,158.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,204.20 C 263.80,231.76 356.99,168.34 440.00,158.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="204.2" r="4" fill="white" />
 <circle cx="239.1" cy="204.2" r="3" fill="#000000" />
-<circle cx="455.0" cy="158.0" r="4" fill="white" />
-<circle cx="455.0" cy="158.0" r="3" fill="#000000" />
 <text x="485.0" y="55.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">BH1750</text>
 <rect x="450.0" y="60.0" width="70.0" height="60.0" rx="5" ry="5" fill="#4A90E2" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="70.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="65.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="72.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
-<circle cx="455.0" cy="78.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="73.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="80.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
-<circle cx="455.0" cy="86.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="81.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="88.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SCL</text>
-<circle cx="455.0" cy="94.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="89.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="96.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SDA</text>
-<circle cx="455.0" cy="102.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="97.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="104.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">ADDR</text>
 <text x="487.5" y="135.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">OLED Display</text>
 <rect x="450.0" y="140.0" width="75.0" height="60.0" rx="5" ry="5" fill="#3498DB" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="150.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="145.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="152.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
-<circle cx="455.0" cy="158.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="153.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="160.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
-<circle cx="455.0" cy="166.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="161.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="168.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SCLK</text>
-<circle cx="455.0" cy="174.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="169.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="176.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">MOSI</text>
-<circle cx="455.0" cy="182.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="177.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="184.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">MISO</text>
-<circle cx="455.0" cy="190.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="185.0" width="16.4" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="192.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">CS</text>
 <text x="475.0" y="215.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">Red LED</text>
 <rect x="450.0" y="220.0" width="50.0" height="40.0" rx="5" ry="5" fill="#E74C3C" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="235.0" r="3" fill="#FFD700" stroke="#333" />
+<path d="M 440.00,235.00 L 457.00,235.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,235.00 L 457.00,235.00" stroke="#808080" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,182.00 L 457.00,182.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,182.00 L 457.00,182.00" stroke="#FF69B4" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,174.00 L 457.00,174.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,174.00 L 457.00,174.00" stroke="#00CED1" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,166.00 L 457.00,166.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,166.00 L 457.00,166.00" stroke="#FFD700" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,150.00 L 457.00,150.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,150.00 L 457.00,150.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,94.00 L 457.00,94.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,94.00 L 457.00,94.00" stroke="#00FF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,86.00 L 457.00,86.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,86.00 L 457.00,86.00" stroke="#0000FF" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,78.00 L 457.00,78.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,78.00 L 457.00,78.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,70.00 L 457.00,70.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,70.00 L 457.00,70.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,247.00 L 457.00,247.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,247.00 L 457.00,247.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,190.00 L 457.00,190.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,190.00 L 457.00,190.00" stroke="#9370DB" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,158.00 L 457.00,158.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,158.00 L 457.00,158.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<circle cx="455.0" cy="70.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="70.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="65.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="72.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
+<circle cx="455.0" cy="78.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="78.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="73.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="80.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
+<circle cx="455.0" cy="86.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="86.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="81.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="88.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SCL</text>
+<circle cx="455.0" cy="94.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="94.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="89.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="96.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SDA</text>
+<circle cx="455.0" cy="102.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="102.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="97.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="104.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">ADDR</text>
+<circle cx="455.0" cy="150.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="150.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="145.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="152.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
+<circle cx="455.0" cy="158.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="158.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="153.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="160.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
+<circle cx="455.0" cy="166.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="166.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="161.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="168.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SCLK</text>
+<circle cx="455.0" cy="174.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="174.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="169.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="176.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">MOSI</text>
+<circle cx="455.0" cy="182.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="182.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="177.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="184.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">MISO</text>
+<circle cx="455.0" cy="190.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="190.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="185.0" width="16.4" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="192.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">CS</text>
+<circle cx="455.0" cy="235.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="235.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="230.0" width="12.2" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="237.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">+</text>
-<circle cx="455.0" cy="247.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="247.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="247.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="242.0" width="12.2" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="249.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">-</text>
 </svg>

--- a/images/ir_led.svg
+++ b/images/ir_led.svg
@@ -1018,33 +1018,36 @@
 <text x="227.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">39</text>
 <circle cx="239.1" cy="324.2" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
 <text x="239.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">40</text>
-<path d="M 227.10,132.20 C 247.00,164.76 341.89,97.21 455.00,85.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,132.20 C 247.00,164.76 341.89,97.21 455.00,85.00" stroke="#808080" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,132.20 C 247.00,164.76 337.39,97.21 440.00,85.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,132.20 C 247.00,164.76 337.39,97.21 440.00,85.00" stroke="#808080" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="132.2" r="4" fill="white" />
 <circle cx="227.1" cy="132.2" r="3" fill="#808080" />
-<circle cx="455.0" cy="85.0" r="4" fill="white" />
-<circle cx="455.0" cy="85.0" r="3" fill="#808080" />
-<path d="M 239.10,120.20 C 253.00,117.24 336.29,93.89 455.00,95.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,120.20 C 253.00,117.24 336.29,93.89 455.00,95.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,120.20 C 253.00,117.24 331.79,93.89 440.00,95.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,120.20 C 253.00,117.24 331.79,93.89 440.00,95.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="120.2" r="4" fill="white" />
 <circle cx="239.1" cy="120.2" r="3" fill="#000000" />
-<circle cx="455.0" cy="95.0" r="4" fill="white" />
-<circle cx="455.0" cy="95.0" r="3" fill="#000000" />
-<path d="M 239.10,96.20 C 250.60,66.60 330.69,63.90 455.00,75.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,96.20 C 250.60,66.60 330.69,63.90 455.00,75.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,96.20 C 250.60,66.60 326.19,63.90 440.00,75.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,96.20 C 250.60,66.60 326.19,63.90 440.00,75.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="96.2" r="4" fill="white" />
 <circle cx="239.1" cy="96.2" r="3" fill="#FF0000" />
-<circle cx="455.0" cy="75.0" r="4" fill="white" />
-<circle cx="455.0" cy="75.0" r="3" fill="#FF0000" />
 <text x="490.0" y="55.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">IR LED Ring (12)</text>
 <rect x="450.0" y="60.0" width="80.0" height="50.0" rx="5" ry="5" fill="#E24A4A" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="75.0" r="3" fill="#FFD700" stroke="#333" />
+<path d="M 440.00,85.00 L 457.00,85.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,85.00 L 457.00,85.00" stroke="#808080" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,95.00 L 457.00,95.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,95.00 L 457.00,95.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,75.00 L 457.00,75.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,75.00 L 457.00,75.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<circle cx="455.0" cy="75.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="75.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="70.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="77.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
-<circle cx="455.0" cy="85.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="85.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="85.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="80.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="87.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">CTRL</text>
-<circle cx="455.0" cy="95.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="95.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="95.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="90.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="97.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
 </svg>

--- a/images/ir_led_ring.svg
+++ b/images/ir_led_ring.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-     width="700.0" height="447.46" viewBox="0 0 700.0 447.46">
+     width="570.0" height="427.46" viewBox="0 0 570.0 427.46">
 <defs>
 </defs>
-<rect x="0" y="0" width="700.0" height="447.46" fill="white" />
-<text x="350.0" y="25" font-size="20" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">12-LED IR Ring Module Wiring</text>
+<rect x="0" y="0" width="570.0" height="427.46" fill="white" />
+<text x="285.0" y="25" font-size="20" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">12-LED IR Ring Module Wiring</text>
 <g transform="translate(40.0, 80.0)">
 <g>
 <g id="g477">
@@ -1018,33 +1018,36 @@
 <text x="227.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">39</text>
 <circle cx="239.1" cy="324.2" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
 <text x="239.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">40</text>
-<path d="M 227.10,144.20 C 244.60,154.28 336.29,98.78 455.00,95.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,144.20 C 244.60,154.28 336.29,98.78 455.00,95.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,144.20 C 244.60,154.28 331.79,98.78 440.00,95.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,144.20 C 244.60,154.28 331.79,98.78 440.00,95.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="144.2" r="4" fill="white" />
 <circle cx="227.1" cy="144.2" r="3" fill="#000000" />
-<circle cx="455.0" cy="95.0" r="4" fill="white" />
-<circle cx="455.0" cy="95.0" r="3" fill="#000000" />
-<path d="M 227.10,156.20 C 253.63,161.96 390.37,86.92 455.00,85.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,156.20 C 253.63,161.96 390.37,86.92 455.00,85.00" stroke="#808080" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,156.20 C 253.63,161.96 381.37,86.92 440.00,85.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,156.20 C 253.63,161.96 381.37,86.92 440.00,85.00" stroke="#808080" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="156.2" r="4" fill="white" />
 <circle cx="227.1" cy="156.2" r="3" fill="#808080" />
-<circle cx="455.0" cy="85.0" r="4" fill="white" />
-<circle cx="455.0" cy="85.0" r="3" fill="#808080" />
-<path d="M 239.10,96.20 C 250.60,81.00 330.69,69.30 455.00,75.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,96.20 C 250.60,81.00 330.69,69.30 455.00,75.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,96.20 C 250.60,81.00 326.19,69.30 440.00,75.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,96.20 C 250.60,81.00 326.19,69.30 440.00,75.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="96.2" r="4" fill="white" />
 <circle cx="239.1" cy="96.2" r="3" fill="#FF0000" />
-<circle cx="455.0" cy="75.0" r="4" fill="white" />
-<circle cx="455.0" cy="75.0" r="3" fill="#FF0000" />
 <text x="490.0" y="55.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">IR_LED_Ring</text>
 <rect x="450.0" y="60.0" width="80.0" height="50.0" rx="5" ry="5" fill="#E24A4A" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="75.0" r="3" fill="#FFD700" stroke="#333" />
+<path d="M 440.00,95.00 L 457.00,95.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,95.00 L 457.00,95.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,85.00 L 457.00,85.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,85.00 L 457.00,85.00" stroke="#808080" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,75.00 L 457.00,75.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,75.00 L 457.00,75.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<circle cx="455.0" cy="75.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="75.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="70.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="77.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
-<circle cx="455.0" cy="85.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="85.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="85.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="80.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="87.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">CTRL</text>
-<circle cx="455.0" cy="95.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="95.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="95.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="90.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="97.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
 </svg>

--- a/images/led_with_resistor.svg
+++ b/images/led_with_resistor.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-     width="670.0" height="447.46" viewBox="0 0 670.0 447.46">
+     width="540.0" height="427.46" viewBox="0 0 540.0 427.46">
 <defs>
 </defs>
-<rect x="0" y="0" width="670.0" height="447.46" fill="white" />
-<text x="335.0" y="25" font-size="20" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">LED with Current-Limiting Resistor</text>
+<rect x="0" y="0" width="540.0" height="427.46" fill="white" />
+<text x="270.0" y="25" font-size="20" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">LED with Current-Limiting Resistor</text>
 <g transform="translate(40.0, 80.0)">
 <g>
 <g id="g477">
@@ -1018,32 +1018,34 @@
 <text x="227.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">39</text>
 <circle cx="239.1" cy="324.2" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
 <text x="239.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">40</text>
-<path d="M 227.10,144.20 C 248.83,124.14 385.57,80.31 455.00,87.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,144.20 C 248.83,124.14 385.57,80.31 455.00,87.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,144.20 C 248.83,124.14 376.57,80.31 440.00,87.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,144.20 C 248.83,124.14 376.57,80.31 440.00,87.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="144.2" r="4" fill="white" />
 <circle cx="227.1" cy="144.2" r="3" fill="#000000" />
-<circle cx="455.0" cy="87.0" r="4" fill="white" />
-<circle cx="455.0" cy="87.0" r="3" fill="#000000" />
-<path d="M 227.10,156.20 Q 252.03,176.26 345.50,111.61" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,156.20 Q 252.03,176.26 345.50,111.61" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
-<g transform="translate(345.50453995761, 111.61005686681213) rotate(-34.669246432783346)">
+<path d="M 227.10,156.20 Q 252.03,176.26 345.02,107.42" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,156.20 Q 252.03,176.26 345.02,107.42" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<g transform="translate(345.01517710687403, 107.41726801629969) rotate(-36.51509517201867)">
 <rect x="-10.0" y="-3.0" width="20.0" height="6.0" fill="white" stroke="#FF0000" stroke-width="2" />
 <path d="M-18.0,0 L-10.0,0" stroke="#FF0000" stroke-width="2" />
 <path d="M10.0,0 L18.0,0" stroke="#FF0000" stroke-width="2" />
 <text x="0" y="-8.0" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" fill="#333" font-weight="bold">220Ω</text>
 </g>
-<path d="M 345.50,111.61 Q 388.77,81.69 455.00,75.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 345.50,111.61 Q 388.77,81.69 455.00,75.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 345.02,107.42 C 379.77,81.69 440.00,75.00 457.00,75.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 345.02,107.42 C 379.77,81.69 440.00,75.00 457.00,75.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="156.2" r="4" fill="white" />
 <circle cx="227.1" cy="156.2" r="3" fill="#FF0000" />
-<circle cx="455.0" cy="75.0" r="4" fill="white" />
-<circle cx="455.0" cy="75.0" r="3" fill="#FF0000" />
 <text x="475.0" y="55.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">Red LED</text>
 <rect x="450.0" y="60.0" width="50.0" height="40.0" rx="5" ry="5" fill="#E74C3C" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="75.0" r="3" fill="#FFD700" stroke="#333" />
+<path d="M 440.00,87.00 L 457.00,87.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,87.00 L 457.00,87.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,75.00 L 457.00,75.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,75.00 L 457.00,75.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<circle cx="455.0" cy="75.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="75.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="70.0" width="12.2" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="77.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">+</text>
-<circle cx="455.0" cy="87.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="87.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="87.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="82.0" width="12.2" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="89.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">-</text>
 </svg>

--- a/images/multi_device.svg
+++ b/images/multi_device.svg
@@ -1018,98 +1018,108 @@
 <text x="227.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">39</text>
 <circle cx="239.1" cy="324.2" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
 <text x="239.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">40</text>
-<path d="M 227.10,216.20 C 261.63,229.10 398.37,168.30 455.00,164.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,216.20 C 261.63,229.10 398.37,168.30 455.00,164.00" stroke="#FF69B4" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,216.20 C 261.63,229.10 389.37,168.30 440.00,164.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,216.20 C 261.63,229.10 389.37,168.30 440.00,164.00" stroke="#FF69B4" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="216.2" r="4" fill="white" />
 <circle cx="227.1" cy="216.2" r="3" fill="#FF69B4" />
-<circle cx="455.0" cy="164.0" r="4" fill="white" />
-<circle cx="455.0" cy="164.0" r="3" fill="#FF69B4" />
-<path d="M 227.10,204.20 C 250.60,188.97 350.29,150.29 455.00,156.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,204.20 C 250.60,188.97 350.29,150.29 455.00,156.00" stroke="#00CED1" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,204.20 C 250.60,188.94 345.79,150.28 440.00,156.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,204.20 C 250.60,188.94 345.79,150.28 440.00,156.00" stroke="#00CED1" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="204.2" r="4" fill="white" />
 <circle cx="227.1" cy="204.2" r="3" fill="#00CED1" />
-<circle cx="455.0" cy="156.0" r="4" fill="white" />
-<circle cx="455.0" cy="156.0" r="3" fill="#00CED1" />
-<path d="M 227.10,228.20 C 264.83,282.54 401.57,166.11 455.00,148.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,228.20 C 264.83,282.54 401.57,166.11 455.00,148.00" stroke="#FFD700" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,228.20 C 264.83,282.58 392.57,166.13 440.00,148.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,228.20 C 264.83,282.58 392.57,166.13 440.00,148.00" stroke="#FFD700" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="228.2" r="4" fill="white" />
 <circle cx="227.1" cy="228.2" r="3" fill="#FFD700" />
-<circle cx="455.0" cy="148.0" r="4" fill="white" />
-<circle cx="455.0" cy="148.0" r="3" fill="#FFD700" />
-<path d="M 227.10,192.20 C 252.03,115.99 388.77,106.60 455.00,132.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,192.20 C 252.03,115.99 388.77,106.60 455.00,132.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,192.20 C 252.03,115.99 379.77,106.60 440.00,132.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,192.20 C 252.03,115.99 379.77,106.60 440.00,132.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="192.2" r="4" fill="white" />
 <circle cx="227.1" cy="192.2" r="3" fill="#FF8C00" />
-<circle cx="455.0" cy="132.0" r="4" fill="white" />
-<circle cx="455.0" cy="132.0" r="3" fill="#FF8C00" />
-<path d="M 227.10,108.20 C 243.40,89.85 333.49,87.12 455.00,94.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,108.20 C 243.40,89.85 333.49,87.12 455.00,94.00" stroke="#00FF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,108.20 C 243.40,89.85 328.99,87.12 440.00,94.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,108.20 C 243.40,89.85 328.99,87.12 440.00,94.00" stroke="#00FF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="108.2" r="4" fill="white" />
 <circle cx="227.1" cy="108.2" r="3" fill="#00FF00" />
-<circle cx="455.0" cy="94.0" r="4" fill="white" />
-<circle cx="455.0" cy="94.0" r="3" fill="#00FF00" />
-<path d="M 227.10,120.20 C 248.20,163.85 344.69,102.37 455.00,86.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,120.20 C 248.20,163.85 344.69,102.37 455.00,86.00" stroke="#0000FF" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,120.20 C 248.20,163.85 340.19,102.37 440.00,86.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,120.20 C 248.20,163.85 340.19,102.37 440.00,86.00" stroke="#0000FF" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="120.2" r="4" fill="white" />
 <circle cx="227.1" cy="120.2" r="3" fill="#0000FF" />
-<circle cx="455.0" cy="86.0" r="4" fill="white" />
-<circle cx="455.0" cy="86.0" r="3" fill="#0000FF" />
-<path d="M 227.10,96.20 C 241.00,50.33 327.89,52.80 455.00,70.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,96.20 C 241.00,50.33 327.89,52.80 455.00,70.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,96.20 C 241.00,50.33 323.39,52.80 440.00,70.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,96.20 C 241.00,50.33 323.39,52.80 440.00,70.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="96.2" r="4" fill="white" />
 <circle cx="227.1" cy="96.2" r="3" fill="#FF8C00" />
-<circle cx="455.0" cy="70.0" r="4" fill="white" />
-<circle cx="455.0" cy="70.0" r="3" fill="#FF8C00" />
-<path d="M 239.10,228.20 C 275.23,315.06 404.77,200.95 455.00,172.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,228.20 C 275.23,315.06 404.77,200.95 455.00,172.00" stroke="#9370DB" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,228.20 C 275.23,315.06 395.77,200.95 440.00,172.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,228.20 C 275.23,315.06 395.77,200.95 440.00,172.00" stroke="#9370DB" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="228.2" r="4" fill="white" />
 <circle cx="239.1" cy="228.2" r="3" fill="#9370DB" />
-<circle cx="455.0" cy="172.0" r="4" fill="white" />
-<circle cx="455.0" cy="172.0" r="3" fill="#9370DB" />
-<path d="M 239.10,204.20 C 262.43,151.96 391.97,122.59 455.00,140.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,204.20 C 262.43,151.96 391.97,122.59 455.00,140.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,204.20 C 262.43,151.96 382.97,122.59 440.00,140.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,204.20 C 262.43,151.96 382.97,122.59 440.00,140.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="204.2" r="4" fill="white" />
 <circle cx="239.1" cy="204.2" r="3" fill="#000000" />
-<circle cx="455.0" cy="140.0" r="4" fill="white" />
-<circle cx="455.0" cy="140.0" r="3" fill="#000000" />
-<path d="M 239.10,120.20 C 254.20,133.20 339.09,82.87 455.00,78.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,120.20 C 254.20,133.20 339.09,82.87 455.00,78.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,120.20 C 254.20,133.20 334.59,82.87 440.00,78.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,120.20 C 254.20,133.20 334.59,82.87 440.00,78.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="120.2" r="4" fill="white" />
 <circle cx="239.1" cy="120.2" r="3" fill="#000000" />
-<circle cx="455.0" cy="78.0" r="4" fill="white" />
-<circle cx="455.0" cy="78.0" r="3" fill="#000000" />
 <text x="487.5" y="55.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">OLED_Display</text>
 <rect x="450.0" y="60.0" width="75.0" height="42.0" rx="5" ry="5" fill="#9B59B6" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="70.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="65.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="72.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
-<circle cx="455.0" cy="78.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="73.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="80.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
-<circle cx="455.0" cy="86.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="81.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="88.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SCL</text>
-<circle cx="455.0" cy="94.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="89.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="96.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SDA</text>
 <text x="487.5" y="117.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">Accel_SPI</text>
 <rect x="450.0" y="122.0" width="75.0" height="60.0" rx="5" ry="5" fill="#3498DB" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="132.0" r="3" fill="#FFD700" stroke="#333" />
+<path d="M 440.00,164.00 L 457.00,164.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,164.00 L 457.00,164.00" stroke="#FF69B4" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,156.00 L 457.00,156.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,156.00 L 457.00,156.00" stroke="#00CED1" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,148.00 L 457.00,148.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,148.00 L 457.00,148.00" stroke="#FFD700" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,132.00 L 457.00,132.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,132.00 L 457.00,132.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,94.00 L 457.00,94.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,94.00 L 457.00,94.00" stroke="#00FF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,86.00 L 457.00,86.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,86.00 L 457.00,86.00" stroke="#0000FF" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,70.00 L 457.00,70.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,70.00 L 457.00,70.00" stroke="#FF8C00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,172.00 L 457.00,172.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,172.00 L 457.00,172.00" stroke="#9370DB" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,140.00 L 457.00,140.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,140.00 L 457.00,140.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,78.00 L 457.00,78.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,78.00 L 457.00,78.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<circle cx="455.0" cy="70.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="70.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="65.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="72.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
+<circle cx="455.0" cy="78.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="78.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="73.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="80.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
+<circle cx="455.0" cy="86.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="86.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="81.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="88.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SCL</text>
+<circle cx="455.0" cy="94.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="94.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="89.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="96.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SDA</text>
+<circle cx="455.0" cy="132.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="132.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="127.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="134.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
-<circle cx="455.0" cy="140.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="140.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="140.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="135.0" width="20.6" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="142.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
-<circle cx="455.0" cy="148.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="148.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="148.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="143.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="150.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SCLK</text>
-<circle cx="455.0" cy="156.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="156.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="156.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="151.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="158.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">MOSI</text>
-<circle cx="455.0" cy="164.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="164.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="164.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="159.0" width="24.8" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="166.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">MISO</text>
-<circle cx="455.0" cy="172.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="172.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="172.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="167.0" width="16.4" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="174.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">CS</text>
 </svg>

--- a/images/traffic_light.svg
+++ b/images/traffic_light.svg
@@ -1018,88 +1018,94 @@
 <text x="227.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">39</text>
 <circle cx="239.1" cy="324.2" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
 <text x="239.1" y="325.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">40</text>
-<path d="M 227.10,180.20 Q 257.80,234.22 339.25,220.09" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,180.20 Q 257.80,234.22 339.25,220.09" stroke="#00FF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
-<g transform="translate(339.2476773785591, 220.0878691772719) rotate(-9.842007154922262)">
+<path d="M 227.10,180.20 Q 257.80,234.22 340.43,219.27" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,180.20 Q 257.80,234.22 340.43,219.27" stroke="#00FF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<g transform="translate(340.4271984317784, 219.2676863018489) rotate(-10.255829712987339)">
 <rect x="-10.0" y="-3.0" width="20.0" height="6.0" fill="white" stroke="#00FF00" stroke-width="2" />
 <path d="M-18.0,0 L-10.0,0" stroke="#00FF00" stroke-width="2" />
 <path d="M10.0,0 L18.0,0" stroke="#00FF00" stroke-width="2" />
 <text x="0" y="-8.0" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" fill="#333" font-weight="bold">220Ω</text>
 </g>
-<path d="M 339.25,220.09 Q 367.09,215.26 455.00,195.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 339.25,220.09 Q 367.09,215.26 455.00,195.00" stroke="#00FF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 340.43,219.27 C 362.59,215.26 440.00,195.00 457.00,195.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 340.43,219.27 C 362.59,215.26 440.00,195.00 457.00,195.00" stroke="#00FF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="180.2" r="4" fill="white" />
 <circle cx="227.1" cy="180.2" r="3" fill="#00FF00" />
-<circle cx="455.0" cy="195.0" r="4" fill="white" />
-<circle cx="455.0" cy="195.0" r="3" fill="#00FF00" />
-<path d="M 227.10,168.20 Q 250.60,163.50 350.23,133.26" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,168.20 Q 250.60,163.50 350.23,133.26" stroke="#FFFF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
-<g transform="translate(350.22548559208, 133.25859732318483) rotate(-16.885494405442177)">
+<path d="M 227.10,168.20 C 250.60,163.50 345.79,133.24 351.23,133.34" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,168.20 C 250.60,163.50 345.79,133.24 351.23,133.34" stroke="#FFFF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<g transform="translate(351.2312045082499, 133.3395073411931) rotate(1.0716392671713657)">
 <rect x="-10.0" y="-3.0" width="20.0" height="6.0" fill="white" stroke="#FFFF00" stroke-width="2" />
 <path d="M-18.0,0 L-10.0,0" stroke="#FFFF00" stroke-width="2" />
 <path d="M10.0,0 L18.0,0" stroke="#FFFF00" stroke-width="2" />
 <text x="0" y="-8.0" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" fill="#333" font-weight="bold">220Ω</text>
 </g>
-<path d="M 350.23,133.26 Q 350.29,133.24 455.00,135.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 350.23,133.26 Q 350.29,133.24 455.00,135.00" stroke="#FFFF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 351.23,133.34 Q 440.00,135.00 457.00,135.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 351.23,133.34 Q 440.00,135.00 457.00,135.00" stroke="#FFFF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="168.2" r="4" fill="white" />
 <circle cx="227.1" cy="168.2" r="3" fill="#FFFF00" />
-<circle cx="455.0" cy="135.0" r="4" fill="white" />
-<circle cx="455.0" cy="135.0" r="3" fill="#FFFF00" />
-<path d="M 227.10,144.20 C 248.83,75.54 385.57,64.11 455.00,87.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,144.20 C 248.83,75.54 385.57,64.11 455.00,87.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,144.20 C 248.83,75.54 376.57,64.11 440.00,87.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,144.20 C 248.83,75.54 376.57,64.11 440.00,87.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="144.2" r="4" fill="white" />
 <circle cx="227.1" cy="144.2" r="3" fill="#000000" />
-<circle cx="455.0" cy="87.0" r="4" fill="white" />
-<circle cx="455.0" cy="87.0" r="3" fill="#000000" />
-<path d="M 227.10,156.20 Q 252.03,127.66 345.21,85.29" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,156.20 Q 252.03,127.66 345.21,85.29" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
-<g transform="translate(345.2136645191308, 85.29121083374321) rotate(-24.450960125215033)">
+<path d="M 227.10,156.20 Q 252.03,127.66 345.52,82.16" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,156.20 Q 252.03,127.66 345.52,82.16" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<g transform="translate(345.51607104449624, 82.15875539821982) rotate(-25.95351468540666)">
 <rect x="-10.0" y="-3.0" width="20.0" height="6.0" fill="white" stroke="#FF0000" stroke-width="2" />
 <path d="M-18.0,0 L-10.0,0" stroke="#FF0000" stroke-width="2" />
 <path d="M10.0,0 L18.0,0" stroke="#FF0000" stroke-width="2" />
 <text x="0" y="-8.0" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" fill="#333" font-weight="bold">220Ω</text>
 </g>
-<path d="M 345.21,85.29 Q 388.77,65.49 455.00,75.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 345.21,85.29 Q 388.77,65.49 455.00,75.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 345.52,82.16 C 379.77,65.49 440.00,75.00 457.00,75.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 345.52,82.16 C 379.77,65.49 440.00,75.00 457.00,75.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="156.2" r="4" fill="white" />
 <circle cx="227.1" cy="156.2" r="3" fill="#FF0000" />
-<circle cx="455.0" cy="75.0" r="4" fill="white" />
-<circle cx="455.0" cy="75.0" r="3" fill="#FF0000" />
-<path d="M 239.10,204.20 C 268.60,209.70 372.69,209.06 455.00,207.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,204.20 C 268.60,209.70 372.69,209.06 455.00,207.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,204.20 C 268.60,209.70 368.19,209.06 440.00,207.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,204.20 C 268.60,209.70 368.19,209.06 440.00,207.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="204.2" r="4" fill="white" />
 <circle cx="239.1" cy="204.2" r="3" fill="#000000" />
-<circle cx="455.0" cy="207.0" r="4" fill="white" />
-<circle cx="455.0" cy="207.0" r="3" fill="#000000" />
-<path d="M 239.10,168.20 C 261.40,199.78 355.89,158.84 455.00,147.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,168.20 C 261.40,199.78 355.89,158.84 455.00,147.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,168.20 C 261.40,199.78 351.39,158.84 440.00,147.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,168.20 C 261.40,199.78 351.39,158.84 440.00,147.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="168.2" r="4" fill="white" />
 <circle cx="239.1" cy="168.2" r="3" fill="#000000" />
-<circle cx="455.0" cy="147.0" r="4" fill="white" />
-<circle cx="455.0" cy="147.0" r="3" fill="#000000" />
 <text x="475.0" y="55.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">Red LED</text>
 <rect x="450.0" y="60.0" width="50.0" height="40.0" rx="5" ry="5" fill="#E74C3C" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="75.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="70.0" width="12.2" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="77.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">+</text>
-<circle cx="455.0" cy="87.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="82.0" width="12.2" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="89.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">-</text>
 <text x="475.0" y="115.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">Yellow LED</text>
 <rect x="450.0" y="120.0" width="50.0" height="40.0" rx="5" ry="5" fill="#E74C3C" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="135.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="130.0" width="12.2" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="137.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">+</text>
-<circle cx="455.0" cy="147.0" r="3" fill="#FFD700" stroke="#333" />
-<rect x="461.0" y="142.0" width="12.2" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="149.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">-</text>
 <text x="475.0" y="175.0" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">Green LED</text>
 <rect x="450.0" y="180.0" width="50.0" height="40.0" rx="5" ry="5" fill="#E74C3C" stroke="#333" stroke-width="2" opacity="0.9" />
-<circle cx="455.0" cy="195.0" r="3" fill="#FFD700" stroke="#333" />
+<path d="M 440.00,195.00 L 457.00,195.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,195.00 L 457.00,195.00" stroke="#00FF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,135.00 L 457.00,135.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,135.00 L 457.00,135.00" stroke="#FFFF00" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,87.00 L 457.00,87.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,87.00 L 457.00,87.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,75.00 L 457.00,75.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,75.00 L 457.00,75.00" stroke="#FF0000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,207.00 L 457.00,207.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,207.00 L 457.00,207.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,147.00 L 457.00,147.00" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,147.00 L 457.00,147.00" stroke="#000000" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<circle cx="455.0" cy="75.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="75.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="70.0" width="12.2" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="77.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">+</text>
+<circle cx="455.0" cy="87.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="87.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="82.0" width="12.2" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="89.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">-</text>
+<circle cx="455.0" cy="135.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="135.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="130.0" width="12.2" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="137.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">+</text>
+<circle cx="455.0" cy="147.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="147.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
+<rect x="461.0" y="142.0" width="12.2" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="149.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">-</text>
+<circle cx="455.0" cy="195.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="195.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="190.0" width="12.2" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="197.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">+</text>
-<circle cx="455.0" cy="207.0" r="3" fill="#FFD700" stroke="#333" />
+<circle cx="455.0" cy="207.0" r="4" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="207.0" r="3" fill="#FFD700" stroke="#333" stroke-width="1" opacity="0.95" />
 <rect x="461.0" y="202.0" width="12.2" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="209.5" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">-</text>
 </svg>


### PR DESCRIPTION
## Summary

This PR improves the visual quality of wire-to-device connections by ensuring wires properly extend into device pin circles, making them clearly visible and connected, similar to the board-side connections.

### Visual Improvements
- Wires now visually penetrate into device pin circles instead of stopping at the edge
- Connection segments are drawn on top of device boxes for proper layering
- Device pins have white halos for better connection visibility

### Technical Changes

**Layout Engine** (`src/pinviz/layout.py`)
- Added 15-pixel straight segment at the end of each wire path
- Extended final wire point 2px beyond pin center to account for stroke width
- Ensures wires are clearly visible inside pin circles

**SVG Renderer** (`src/pinviz/render_svg.py`)
- Split device rendering into `_draw_device_box()` and `_draw_device_pins()` 
- Split wire rendering to optionally skip final connection segment
- Added `_draw_wire_connection_segment()` for separate connection layer
- Updated drawing order:
  1. Wire curves (behind devices)
  2. Device boxes
  3. Wire connection segments (on top of device boxes)
  4. Device pins (on top of everything)

**Examples**
- Regenerated all 9 example SVG diagrams with improved connections

### Before & After

**Before:** Wires appeared to stop outside device pin circles, making connections unclear

**After:** Wires clearly extend into the center of device pin circles, matching board-side connection quality

## Test Plan

- [x] All example diagrams regenerate successfully
- [x] Wire connection segments visible on top of device boxes
- [x] Code passes ruff formatting checks
- [x] No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)