### PR TITLE
fix: prevent traceback when exiting device wizard

### DIFF
--- a/src/pinviz/cli/commands/device.py
+++ b/src/pinviz/cli/commands/device.py
@@ -33,6 +33,10 @@ def add_device_command() -> None:
         if exit_code != 0:
             raise typer.Exit(code=exit_code)
 
+    except typer.Exit:
+        # Let typer.Exit propagate - it's a normal exit mechanism, not an error
+        raise
+
     except KeyboardInterrupt:
         ctx.console.print("\n")
         print_error("Wizard cancelled by user", ctx.console)


### PR DESCRIPTION
## Summary
- Fixed unprofessional traceback when exiting the `add-device` wizard
- Added explicit `typer.Exit` exception handling to let exits propagate cleanly

## Problem
When users exit the device wizard by choosing "No" to the overwrite prompt, a `typer.Exit` exception was being caught by the generic exception handler at line 42, resulting in:
- Error logs with traceback
- Unprofessional output that makes it look like something went wrong

## Solution
Added a specific exception handler for `typer.Exit` that re-raises the exception without logging, matching the pattern already used in other commands (`render.py:121`, `validate.py:91`).

## Test Plan
- [x] Run `pinviz add-device` and answer "No" to overwrite prompt
- [x] Verify no traceback is shown
- [x] Run `ruff format` and `ruff check` - all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)