### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-tests.yml
+++ b/.github/workflows/validate-tests.yml
@@ -1,5 +1,8 @@
 name: Validate Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/nordstad/PinViz/security/code-scanning/8](https://github.com/nordstad/PinViz/security/code-scanning/8)

In general, the fix is to explicitly define a minimal `permissions` block for the workflow or for the specific job, limiting the `GITHUB_TOKEN` to read-only repository contents since the job only needs to check out code and run local scripts.

The best fix here is to add a workflow-level `permissions` block right after the `name:` declaration, setting `contents: read`. This will apply to all jobs in the workflow (currently just `validate-post-publish-tests`) and avoid repeating configuration. No additional permissions (like `pull-requests: write`) are needed because the job does not modify GitHub resources.

Concretely:
- Edit `.github/workflows/validate-tests.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Validate Tests`) and before the `on:` block.
- No new imports, methods, or definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
