### PR TITLE
[Phase 1.3] Pin Compatibility Matrix and Validation

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -3,7 +3,7 @@
 from pinviz import boards
 from pinviz.devices import get_registry
 from pinviz.model import Connection, Device, DevicePin, Diagram, PinRole, Point
-from pinviz.validation import DiagramValidator, ValidationLevel
+from pinviz.validation import DiagramValidator, ValidationLevel, check_pin_compatibility
 
 
 class TestDuplicatePinDetection:
@@ -385,3 +385,362 @@ class TestValidDiagrams:
         # Should have no errors
         errors = [i for i in issues if i.level == ValidationLevel.ERROR]
         assert len(errors) == 0
+
+
+class TestPinCompatibilityMatrix:
+    """Tests for the pin compatibility matrix function."""
+
+    def test_compatible_power_connections(self):
+        """Test that same voltage power connections are compatible."""
+        is_compat, severity = check_pin_compatibility(PinRole.POWER_3V3, PinRole.POWER_3V3)
+        assert is_compat is True
+        assert severity is None
+
+        is_compat, severity = check_pin_compatibility(PinRole.POWER_5V, PinRole.POWER_5V)
+        assert is_compat is True
+        assert severity is None
+
+    def test_power_to_ground_dangerous(self):
+        """Test that power to ground connections are detected as dangerous."""
+        is_compat, severity = check_pin_compatibility(PinRole.POWER_3V3, PinRole.GROUND)
+        assert is_compat is False
+        assert severity == "error"
+
+        is_compat, severity = check_pin_compatibility(PinRole.POWER_5V, PinRole.GROUND)
+        assert is_compat is False
+        assert severity == "error"
+
+    def test_cross_voltage_power_connections(self):
+        """Test that cross-voltage power connections are detected."""
+        # 5V to 3.3V device - dangerous
+        is_compat, severity = check_pin_compatibility(PinRole.POWER_5V, PinRole.POWER_3V3)
+        assert is_compat is False
+        assert severity == "error"
+
+        # 3.3V to 5V device - warning (may not work)
+        is_compat, severity = check_pin_compatibility(PinRole.POWER_3V3, PinRole.POWER_5V)
+        assert is_compat is False
+        assert severity == "warning"
+
+    def test_i2c_pin_compatibility(self):
+        """Test I2C pin role compatibility."""
+        # SDA to SDA is OK
+        is_compat, severity = check_pin_compatibility(PinRole.I2C_SDA, PinRole.I2C_SDA)
+        assert is_compat is True
+        assert severity is None
+
+        # SCL to SCL is OK
+        is_compat, severity = check_pin_compatibility(PinRole.I2C_SCL, PinRole.I2C_SCL)
+        assert is_compat is True
+        assert severity is None
+
+        # SDA to SCL is swapped - error
+        is_compat, severity = check_pin_compatibility(PinRole.I2C_SDA, PinRole.I2C_SCL)
+        assert is_compat is False
+        assert severity == "error"
+
+        # SCL to SDA is swapped - error
+        is_compat, severity = check_pin_compatibility(PinRole.I2C_SCL, PinRole.I2C_SDA)
+        assert is_compat is False
+        assert severity == "error"
+
+    def test_spi_pin_compatibility(self):
+        """Test SPI pin role compatibility."""
+        # MOSI to MOSI is OK
+        is_compat, severity = check_pin_compatibility(PinRole.SPI_MOSI, PinRole.SPI_MOSI)
+        assert is_compat is True
+        assert severity is None
+
+        # MISO to MISO is OK
+        is_compat, severity = check_pin_compatibility(PinRole.SPI_MISO, PinRole.SPI_MISO)
+        assert is_compat is True
+        assert severity is None
+
+        # MOSI to MISO is swapped - error
+        is_compat, severity = check_pin_compatibility(PinRole.SPI_MOSI, PinRole.SPI_MISO)
+        assert is_compat is False
+        assert severity == "error"
+
+    def test_uart_pin_compatibility(self):
+        """Test UART pin role compatibility."""
+        # TX to RX is correct
+        is_compat, severity = check_pin_compatibility(PinRole.UART_TX, PinRole.UART_RX)
+        assert is_compat is True
+        assert severity is None
+
+        # RX to TX is correct
+        is_compat, severity = check_pin_compatibility(PinRole.UART_RX, PinRole.UART_TX)
+        assert is_compat is True
+        assert severity is None
+
+        # TX to TX won't work
+        is_compat, severity = check_pin_compatibility(PinRole.UART_TX, PinRole.UART_TX)
+        assert is_compat is False
+        assert severity == "error"
+
+        # RX to RX won't work
+        is_compat, severity = check_pin_compatibility(PinRole.UART_RX, PinRole.UART_RX)
+        assert is_compat is False
+        assert severity == "error"
+
+    def test_gpio_compatibility(self):
+        """Test GPIO pin compatibility with various roles."""
+        # GPIO to GPIO is OK
+        is_compat, severity = check_pin_compatibility(PinRole.GPIO, PinRole.GPIO)
+        assert is_compat is True
+        assert severity is None
+
+        # GPIO to PWM is OK
+        is_compat, severity = check_pin_compatibility(PinRole.GPIO, PinRole.PWM)
+        assert is_compat is True
+        assert severity is None
+
+        # GPIO to protocol pins - warning (might be bit-banging)
+        is_compat, severity = check_pin_compatibility(PinRole.GPIO, PinRole.I2C_SDA)
+        assert is_compat is True
+        assert severity == "warning"
+
+    def test_ground_compatibility(self):
+        """Test ground pin compatibility."""
+        # Ground to ground is always OK
+        is_compat, severity = check_pin_compatibility(PinRole.GROUND, PinRole.GROUND)
+        assert is_compat is True
+        assert severity is None
+
+
+class TestPinRoleCompatibilityValidation:
+    """Tests for pin role compatibility validation in diagrams."""
+
+    def test_swapped_i2c_lines_detected(self):
+        """Test detection of swapped I2C SDA/SCL lines."""
+        board = boards.raspberry_pi_5()
+
+        # Create device with I2C pins
+        device = Device(
+            name="I2C Sensor",
+            pins=[
+                DevicePin("VCC", PinRole.POWER_3V3, Point(5, 10)),
+                DevicePin("GND", PinRole.GROUND, Point(5, 20)),
+                DevicePin("SDA", PinRole.I2C_SDA, Point(5, 30)),
+                DevicePin("SCL", PinRole.I2C_SCL, Point(5, 40)),
+            ],
+        )
+
+        # Swap SDA and SCL connections - this is wrong!
+        connections = [
+            Connection(1, "I2C Sensor", "VCC"),
+            Connection(6, "I2C Sensor", "GND"),
+            Connection(3, "I2C Sensor", "SCL"),  # Pin 3 is I2C_SDA, should connect to SDA
+            Connection(5, "I2C Sensor", "SDA"),  # Pin 5 is I2C_SCL, should connect to SCL
+        ]
+
+        diagram = Diagram(
+            title="Test",
+            board=board,
+            devices=[device],
+            connections=connections,
+        )
+
+        validator = DiagramValidator()
+        issues = validator.validate(diagram)
+
+        errors = [i for i in issues if i.level == ValidationLevel.ERROR]
+        assert len(errors) >= 2  # Two swapped connections
+        assert any("I2C_SDA" in e.message and "I2C_SCL" in e.message for e in errors)
+
+    def test_power_to_ground_short_detected(self):
+        """Test detection of dangerous power-to-ground short circuit."""
+        board = boards.raspberry_pi_5()
+
+        # Create device with ground pin
+        device = Device(
+            name="Device",
+            pins=[DevicePin("GND", PinRole.GROUND, Point(5, 10))],
+        )
+
+        # Connect power pin to ground - DANGEROUS!
+        connections = [
+            Connection(1, "Device", "GND"),  # Pin 1 is 3.3V power
+        ]
+
+        diagram = Diagram(
+            title="Test",
+            board=board,
+            devices=[device],
+            connections=connections,
+        )
+
+        validator = DiagramValidator()
+        issues = validator.validate(diagram)
+
+        errors = [i for i in issues if i.level == ValidationLevel.ERROR]
+        assert len(errors) >= 1
+        assert any("3V3" in e.message and "GND" in e.message for e in errors)
+
+    def test_swapped_spi_lines_detected(self):
+        """Test detection of swapped SPI MOSI/MISO lines."""
+        board = boards.raspberry_pi_5()
+
+        # Create SPI device
+        device = Device(
+            name="SPI Device",
+            pins=[
+                DevicePin("MOSI", PinRole.SPI_MOSI, Point(5, 10)),
+                DevicePin("MISO", PinRole.SPI_MISO, Point(5, 20)),
+                DevicePin("SCLK", PinRole.SPI_SCLK, Point(5, 30)),
+            ],
+        )
+
+        # Swap MOSI and MISO - this is wrong!
+        connections = [
+            Connection(19, "SPI Device", "MISO"),  # Pin 19 is SPI_MOSI
+            Connection(21, "SPI Device", "MOSI"),  # Pin 21 is SPI_MISO
+            Connection(23, "SPI Device", "SCLK"),
+        ]
+
+        diagram = Diagram(
+            title="Test",
+            board=board,
+            devices=[device],
+            connections=connections,
+        )
+
+        validator = DiagramValidator()
+        issues = validator.validate(diagram)
+
+        errors = [i for i in issues if i.level == ValidationLevel.ERROR]
+        assert len(errors) >= 2
+        assert any("SPI_MOSI" in e.message and "SPI_MISO" in e.message for e in errors)
+
+    def test_uart_tx_to_tx_error(self):
+        """Test detection of UART TX connected to TX (won't work)."""
+        board = boards.raspberry_pi_5()
+
+        # Create UART device
+        device = Device(
+            name="UART Device",
+            pins=[
+                DevicePin("TX", PinRole.UART_TX, Point(5, 10)),
+                DevicePin("RX", PinRole.UART_RX, Point(5, 20)),
+            ],
+        )
+
+        # Connect TX to TX - this won't work!
+        connections = [
+            Connection(8, "UART Device", "TX"),  # Pin 8 is UART_TX
+            Connection(10, "UART Device", "RX"),
+        ]
+
+        diagram = Diagram(
+            title="Test",
+            board=board,
+            devices=[device],
+            connections=connections,
+        )
+
+        validator = DiagramValidator()
+        issues = validator.validate(diagram)
+
+        errors = [i for i in issues if i.level == ValidationLevel.ERROR]
+        assert len(errors) >= 1
+        assert any("UART_TX" in e.message for e in errors)
+
+    def test_device_to_device_pin_compatibility(self):
+        """Test pin compatibility validation for device-to-device connections."""
+        board = boards.raspberry_pi_5()
+
+        # Create two devices
+        power_module = Device(
+            name="Power Module",
+            pins=[
+                DevicePin("VIN", PinRole.POWER_5V, Point(5, 10)),
+                DevicePin("VOUT", PinRole.POWER_3V3, Point(5, 20)),
+                DevicePin("GND", PinRole.GROUND, Point(5, 30)),
+            ],
+        )
+
+        sensor = Device(
+            name="Sensor",
+            pins=[
+                DevicePin("VCC", PinRole.POWER_3V3, Point(5, 10)),
+                DevicePin("GND", PinRole.GROUND, Point(5, 20)),
+            ],
+        )
+
+        # Connections:
+        # - Board 5V to power module input (OK)
+        # - Power module 3.3V output to sensor VCC (OK)
+        # - Shared ground (OK)
+        connections = [
+            Connection(board_pin=2, device_name="Power Module", device_pin_name="VIN"),
+            Connection(board_pin=6, device_name="Power Module", device_pin_name="GND"),
+            Connection(
+                source_device="Power Module",
+                source_pin="VOUT",
+                device_name="Sensor",
+                device_pin_name="VCC",
+            ),
+            Connection(board_pin=6, device_name="Sensor", device_pin_name="GND"),
+        ]
+
+        diagram = Diagram(
+            title="Test",
+            board=board,
+            devices=[power_module, sensor],
+            connections=connections,
+        )
+
+        validator = DiagramValidator()
+        issues = validator.validate(diagram)
+
+        # Should have no errors - this is a valid power distribution setup
+        errors = [i for i in issues if i.level == ValidationLevel.ERROR]
+        assert len(errors) == 0
+
+    def test_device_to_device_incompatible_pins(self):
+        """Test detection of incompatible pins in device-to-device connections."""
+        board = boards.raspberry_pi_5()
+
+        # Create two devices with incompatible pin connection
+        device1 = Device(
+            name="Device1",
+            pins=[
+                DevicePin("OUT", PinRole.POWER_5V, Point(5, 10)),
+                DevicePin("GND", PinRole.GROUND, Point(5, 20)),
+            ],
+        )
+
+        device2 = Device(
+            name="Device2",
+            pins=[
+                DevicePin("IN", PinRole.POWER_3V3, Point(5, 10)),
+                DevicePin("GND", PinRole.GROUND, Point(5, 20)),
+            ],
+        )
+
+        # Connect 5V output to 3.3V input - dangerous!
+        connections = [
+            Connection(board_pin=2, device_name="Device1", device_pin_name="OUT"),
+            Connection(board_pin=6, device_name="Device1", device_pin_name="GND"),
+            Connection(board_pin=6, device_name="Device2", device_pin_name="GND"),
+            Connection(
+                source_device="Device1",
+                source_pin="OUT",
+                device_name="Device2",
+                device_pin_name="IN",
+            ),
+        ]
+
+        diagram = Diagram(
+            title="Test",
+            board=board,
+            devices=[device1, device2],
+            connections=connections,
+        )
+
+        validator = DiagramValidator()
+        issues = validator.validate(diagram)
+
+        errors = [i for i in issues if i.level == ValidationLevel.ERROR]
+        assert len(errors) >= 1
+        assert any("5V" in e.message and "3V3" in e.message for e in errors)


### PR DESCRIPTION
## Summary

Implements **Phase 1.3: Pin Compatibility Matrix and Validation** (#89) from the Multi-Level Device Support milestone (v0.11.0).

This PR adds comprehensive pin role compatibility validation to prevent common wiring mistakes and dangerous connections.

## Changes

### 1. Pin Compatibility Matrix (`PIN_COMPATIBILITY_MATRIX`)
- Defines safe pin role pairings for all connection types
- Covers power, ground, I2C, SPI, UART, PWM, GPIO, and PCM connections
- Categorizes incompatibilities as ERROR (dangerous) or WARNING (questionable)

### 2. Validation Logic
- **New function**: `check_pin_compatibility(source_role, target_role)` - validates pin role pairs
- **New method**: `_check_pin_role_compatibility()` - validates all connections in a diagram
- **Enhanced method**: `_check_connection_validity()` - now supports device-to-device connections

### 3. Detected Issues

**Errors (dangerous connections):**
- Power to ground short circuits (3.3V/5V → GND)
- Cross-voltage mismatches (5V → 3.3V device)
- Swapped I2C lines (SDA ↔ SCL)
- Swapped SPI lines (MOSI ↔ MISO)
- UART TX to TX or RX to RX connections
- Power to protocol pin connections

**Warnings (questionable but may be intentional):**
- 3.3V to 5V device (underpowered)
- GPIO to protocol pins (software bit-banging)
- Other unlisted combinations

### 4. Comprehensive Test Coverage

Added 14 new test cases:
- Pin compatibility matrix function tests (8 tests)
- Diagram validation integration tests (6 tests)
- Device-to-device connection validation tests

All tests pass ✅

## Test Plan

- [x] All existing tests pass
- [x] New pin compatibility matrix tests pass
- [x] Board-to-device connection validation tests pass
- [x] Device-to-device connection validation tests pass
- [x] Code formatted with ruff
- [x] Code passes ruff checks

## Breaking Changes

None - this is a non-breaking enhancement that adds additional validation checks.

## Related Issues

- Closes #89
- Part of milestone #1 (Multi-Level Device Support v0.11.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)