### PR TITLE
docs: Add supported boards table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ PinViz makes it easy to create clear, professional wiring diagrams for your Rasp
 - ✨ **Modern CLI**: Rich terminal output with progress indicators and colored messages
 - 🔧 **JSON Output**: Machine-readable output for CI/CD integration
 
+## Supported Boards
+
+| Board              | Aliases                            | GPIO Pins            | Description                                          |
+| ------------------ | ---------------------------------- | -------------------- | ---------------------------------------------------- |
+| Raspberry Pi 5     | `raspberry_pi_5`, `rpi5`, `rpi`    | 40-pin               | Latest Raspberry Pi with improved GPIO capabilities  |
+| Raspberry Pi 4     | `raspberry_pi_4`, `rpi4`           | 40-pin               | Popular Raspberry Pi model with full GPIO header     |
+| Raspberry Pi Pico  | `raspberry_pi_pico`, `pico`        | 40-pin (dual-sided)  | RP2040-based microcontroller board                   |
+
+All boards include full pin definitions with GPIO numbers, I2C, SPI, UART, and PWM support.
+
 ## Installation
 
 Install as a standalone tool with global CLI access:


### PR DESCRIPTION
## Summary

- Add comprehensive supported boards table after the Features section
- Include Raspberry Pi 4, 5, and Pico with their aliases
- Document GPIO pin configurations and board descriptions
- Add note about pin definitions support (GPIO, I2C, SPI, UART, PWM)

## Changes

Added a new "Supported Boards" section with a properly formatted markdown table showing:
- **Raspberry Pi 5**: aliases `raspberry_pi_5`, `rpi5`, `rpi` (40-pin)
- **Raspberry Pi 4**: aliases `raspberry_pi_4`, `rpi4` (40-pin)
- **Raspberry Pi Pico**: aliases `raspberry_pi_pico`, `pico` (40-pin dual-sided)

This provides users with immediate visibility of supported hardware options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)