### PR TITLE
docs: Add comprehensive multi-level device support documentation (fixes #86)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,44 @@ pinviz add-device
 5. **Layout Engine** (`layout.py`): Positions devices and routes wires algorithmically
 6. **SVG Renderer** (`render_svg.py`): Converts diagrams to SVG using `drawsvg`
 7. **CLI** (`cli/`): Modular Typer-based CLI with Rich output and JSON support
+8. **Connection Graph** (`connection_graph.py`): Multi-level device connection validation and analysis
+
+### Multi-Level Device Support (v0.11.0+)
+
+#### Connection Model
+
+`Connection` dataclass supports both board and device sources:
+
+- `board_pin: int | None` - Board source (backward compatible)
+- `source_device: str | None` - Device source (new)
+- `source_pin: str | None` - Source pin on device (new)
+
+#### Connection Graph
+
+`ConnectionGraph` class (src/pinviz/connection_graph.py):
+
+- Builds directed graph from connections
+- Calculates device levels via BFS
+- Detects cycles using DFS
+- Validates pin compatibility
+
+#### Layout Strategy
+
+Multi-tier horizontal layout:
+
+- Devices positioned in tiers based on connection depth
+- Each tier gets its own X position
+- Vertical stacking within each tier
+- Dynamic spacing based on device widths
+
+#### Wire Routing
+
+Device-to-device routing:
+
+- Each tier has routing zone on right side
+- Wires flow horizontally through inter-tier zones
+- Bezier curves for smooth appearance
+- Backward connections (higher → lower level) supported
 
 ### Key Design Patterns
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 
 PinViz makes it easy to create clear, professional wiring diagrams for your Raspberry Pi projects. Define your connections using simple YAML/JSON files or Python code, and automatically generate publication-ready SVG diagrams.
 
-
 ## Example Diagram
 
 <p align="center">
@@ -39,6 +38,32 @@ PinViz makes it easy to create clear, professional wiring diagrams for your Rasp
 - 📦 **SVG Output**: Scalable, high-quality vector graphics
 - ✨ **Modern CLI**: Rich terminal output with progress indicators and colored messages
 - 🔧 **JSON Output**: Machine-readable output for CI/CD integration
+
+## Multi-Level Device Support ✨
+
+**New in v0.11.0**: PinViz now supports device-to-device connections, enabling complex multi-level wiring diagrams!
+
+### What's New
+
+- Connect devices to other devices (not just to the board)
+- Automatic horizontal tier layout based on connection depth
+- Supports power distribution chains, sensor chains, motor controllers, and more
+- Backward compatible with existing configurations
+
+### Example: Power Distribution Chain
+
+```yaml
+connections:
+  # Board to regulator
+  - from: {board_pin: 2}
+    to: {device: "Regulator", device_pin: "VIN"}
+
+  # Regulator to LED (device-to-device!)
+  - from: {device: "Regulator", device_pin: "VOUT"}
+    to: {device: "LED", device_pin: "VCC"}
+```
+
+See [examples/multi_level_simple.yaml](examples/multi_level_simple.yaml) for a complete example.
 
 ## Supported Boards
 
@@ -67,8 +92,6 @@ uv add pinviz
 # Using pip
 pip install pinviz
 ```
-
-
 
 ## Quick Start
 

--- a/docs/multi-level-connections.md
+++ b/docs/multi-level-connections.md
@@ -1,0 +1,155 @@
+# Multi-Level Device Connections Guide
+
+## Overview
+
+Multi-level support allows you to create diagrams where devices connect to other devices, not just to the board. This enables realistic representations of:
+
+- Power distribution networks
+- Signal processing chains
+- Motor control setups
+- Complex projects with intermediate components
+
+## Configuration Syntax
+
+### Board-to-Device (Original Format)
+
+Still fully supported:
+
+```yaml
+connections:
+  - board_pin: 1
+    device: "LED"
+    device_pin: "VCC"
+```
+
+### Device-to-Device (New Format)
+
+```yaml
+connections:
+  - from:
+      device: "Regulator"
+      device_pin: "VOUT"
+    to:
+      device: "LED"
+      device_pin: "VCC"
+```
+
+### Unified Format (Recommended)
+
+For clarity, you can use the `from/to` syntax for all connections:
+
+```yaml
+connections:
+  # Board source
+  - from: {board_pin: 1}
+    to: {device: "LED", device_pin: "VCC"}
+
+  # Device source
+  - from: {device: "Regulator", device_pin: "VOUT"}
+    to: {device: "LED", device_pin: "VCC"}
+```
+
+## Layout Behavior
+
+Devices are automatically positioned in horizontal tiers based on connection depth:
+
+- **Level 0**: Devices directly connected to board
+- **Level 1**: Devices connected to Level 0 devices
+- **Level 2**: Devices connected to Level 1 devices
+- And so on...
+
+## Validation
+
+PinViz automatically validates your connection graph:
+
+```bash
+pinviz validate examples/power_distribution.yaml --show-graph
+```
+
+Common validation checks:
+
+- **Cycle detection**: Ensures no circular dependencies
+- **Pin compatibility**: Warns about voltage mismatches
+- **Orphaned devices**: Flags unconnected devices
+
+## Examples
+
+See the `examples/` directory for complete examples:
+
+- `multi_level_simple.yaml` - Basic power chain
+- `multi_level_branching.yaml` - Tree structure
+- `power_distribution.yaml` - Realistic project
+- `pico_power_chain.yaml` - Pico-based power distribution
+
+## Troubleshooting
+
+### "Cycle detected" Error
+
+Your configuration has circular dependencies:
+
+```text
+Device A → Device B → Device C → Device A
+```
+
+**Solution:** Remove one connection to break the cycle.
+
+### "Pin role incompatible" Warning
+
+Example: Connecting 5V output to 3.3V input.
+
+**Solution:** Add voltage regulator or level shifter.
+
+### "Device positioned incorrectly"
+
+Very deep chains (>10 levels) may have layout issues.
+
+**Solution:** Simplify diagram or break into multiple diagrams.
+
+## Advanced Features
+
+### Mixed Connection Types
+
+You can mix board-to-device and device-to-device connections in the same diagram:
+
+```yaml
+connections:
+  # Power from board
+  - from: {board_pin: 2}
+    to: {device: "Regulator", device_pin: "VIN"}
+
+  # Regulated power to multiple devices
+  - from: {device: "Regulator", device_pin: "VOUT"}
+    to: {device: "LED1", device_pin: "+"}
+
+  - from: {device: "Regulator", device_pin: "VOUT"}
+    to: {device: "LED2", device_pin: "+"}
+
+  # Data from board
+  - from: {board_pin: 3}
+    to: {device: "Sensor", device_pin: "SDA"}
+```
+
+### Wire Styling
+
+Device-to-device connections support all wire styling options:
+
+```yaml
+connections:
+  - from: {device: "Regulator", device_pin: "VOUT"}
+    to: {device: "LED", device_pin: "VCC"}
+    color: "#FF0000"
+    style: "curved"
+```
+
+### Inline Components
+
+Add resistors, capacitors, or diodes on device-to-device connections:
+
+```yaml
+connections:
+  - from: {device: "Regulator", device_pin: "VOUT"}
+    to: {device: "LED", device_pin: "+"}
+    components:
+      - type: "resistor"
+        value: "220Ω"
+```


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the multi-level device support feature introduced in v0.11.0, addressing all requirements in issue #86.

## Changes

### README.md
- Added **Multi-Level Device Support** section highlighting:
  - Device-to-device connections
  - Automatic horizontal tier layout
  - Power distribution chains, sensor chains, etc.
  - Example YAML configuration
  - Link to complete example file

### docs/multi-level-connections.md (NEW)
Created comprehensive guide covering:
- **Overview**: What multi-level support enables
- **Configuration Syntax**: 
  - Original board-to-device format (backward compatible)
  - New device-to-device format
  - Unified `from/to` syntax (recommended)
- **Layout Behavior**: Automatic tier-based positioning
- **Validation**: Cycle detection, pin compatibility, orphaned devices
- **Examples**: Links to example files
- **Troubleshooting**: 
  - Cycle detection errors
  - Pin role incompatibility warnings
  - Device positioning issues
- **Advanced Features**: 
  - Mixed connection types
  - Wire styling on device-to-device connections
  - Inline components support

### CLAUDE.md
Updated architecture documentation with:
- Added Connection Graph to Core Components list
- New **Multi-Level Device Support (v0.11.0+)** section:
  - Connection model details (board_pin, source_device, source_pin)
  - ConnectionGraph class capabilities
  - Multi-tier horizontal layout strategy
  - Device-to-device wire routing approach

## Issue Requirements Met

- ✅ Update README.md with feature announcement
- ✅ Create docs/multi-level-connections.md guide
- ✅ Update CLAUDE.md with architecture details
- ✅ All documentation uses correct syntax
- ✅ Examples referenced with links
- ✅ Add troubleshooting section

## Testing

- Markdown linting performed
- All example file references verified to exist
- Documentation follows existing project style

🤖 Generated with [Claude Code](https://claude.com/claude-code)