### PR TITLE
fix: add bounds checking to wire conflict resolution (fixes #119)

### DIFF
--- a/src/pinviz/layout.py
+++ b/src/pinviz/layout.py
@@ -119,6 +119,7 @@ class LayoutConstants:
 
     # Conflict resolution constants
     CONFLICT_ADJUSTMENT_DIVISOR: float = 2.0  # Divisor for adjusting conflicting wires
+    MAX_ADJUSTMENT: float = 50.0  # Maximum total adjustment per wire to prevent unbounded offsets
 
     # Wire path calculation constants
     STRAIGHT_SEGMENT_LENGTH: float = 15.0  # Length of straight segment at device pin end
@@ -1059,8 +1060,19 @@ class LayoutEngine:
             # Push wire_a up, wire_b down
             wire_a_idx = conflict["wire_a"]
             wire_b_idx = conflict["wire_b"]
-            adjustments[wire_a_idx] = adjustments.get(wire_a_idx, 0.0) - adjustment_amount
-            adjustments[wire_b_idx] = adjustments.get(wire_b_idx, 0.0) + adjustment_amount
+
+            # Clamp adjustments to prevent unbounded offsets
+            current_a = adjustments.get(wire_a_idx, 0.0)
+            current_b = adjustments.get(wire_b_idx, 0.0)
+
+            adjustments[wire_a_idx] = max(
+                -self.constants.MAX_ADJUSTMENT,
+                min(self.constants.MAX_ADJUSTMENT, current_a - adjustment_amount),
+            )
+            adjustments[wire_b_idx] = max(
+                -self.constants.MAX_ADJUSTMENT,
+                min(self.constants.MAX_ADJUSTMENT, current_b + adjustment_amount),
+            )
 
         return adjustments
 


### PR DESCRIPTION
## Summary

Adds bounds checking to wire conflict resolution to prevent unbounded Y-offset adjustments that could push wires off-screen or into negative coordinates.

## Changes

- Added `MAX_ADJUSTMENT` constant (50.0) to `LayoutConstants` class
- Updated wire conflict resolution to clamp adjustments to ±50.0 range
- Prevents accumulation of unbounded offsets when resolving multiple overlapping wire conflicts

## Implementation

The fix adds bounds checking using `max()` and `min()` to clamp adjustments:

```python
adjustments[wire_idx] = max(
    -self.constants.MAX_ADJUSTMENT,
    min(self.constants.MAX_ADJUSTMENT, current + adjustment_amount),
)
```

This ensures that regardless of how many conflicts a wire has, its total adjustment stays within ±50.0 pixels.

## Testing

- All 794 existing tests pass
- Code passes ruff linting and formatting checks
- No breaking changes to existing functionality

## Related Issue

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)