### PR TITLE
feat: make device registry instantiable for better testing (fixes #126)

### DIFF
--- a/src/pinviz/devices/__init__.py
+++ b/src/pinviz/devices/__init__.py
@@ -10,13 +10,28 @@ Use the registry to create device instances:
     led = registry.create('led', color_name='Blue')
     display = registry.create('ssd1306')
 
+For testing or isolated contexts, create independent registries:
+
+    from pinviz.devices import create_registry
+
+    test_registry = create_registry()
+    # Use test_registry independently without affecting global state
+
 Available devices are automatically discovered from JSON configs.
 """
 
-from .registry import DeviceRegistry, DeviceTemplate, get_registry
+from .registry import (
+    DeviceRegistry,
+    DeviceTemplate,
+    create_registry,
+    get_registry,
+    reset_default_registry,
+)
 
 __all__ = [
     "DeviceRegistry",
     "DeviceTemplate",
+    "create_registry",
     "get_registry",
+    "reset_default_registry",
 ]

--- a/tests/test_registry_isolation.py
+++ b/tests/test_registry_isolation.py
@@ -1,0 +1,54 @@
+"""Tests for instantiable device registry pattern (issue #126)."""
+
+from pinviz.devices import create_registry, get_registry, reset_default_registry
+
+
+def test_create_registry_returns_new_instance():
+    """Test that create_registry() returns a new independent instance."""
+    registry1 = create_registry()
+    registry2 = create_registry()
+    assert registry1 is not registry2
+
+
+def test_get_registry_returns_same_instance():
+    """Test that get_registry() returns the same cached instance."""
+    registry1 = get_registry()
+    registry2 = get_registry()
+    assert registry1 is registry2
+
+
+def test_get_registry_and_create_registry_are_independent():
+    """Test that default registry and created registries are independent."""
+    default_registry = get_registry()
+    created_registry = create_registry()
+    assert default_registry is not created_registry
+
+
+def test_reset_default_registry():
+    """Test that reset_default_registry() causes new instance on next call."""
+    registry1 = get_registry()
+    reset_default_registry()
+    registry2 = get_registry()
+    # After reset, should get a new instance
+    assert registry1 is not registry2
+
+
+def test_created_registry_has_same_devices():
+    """Test that created registries have access to same device configs."""
+    default_registry = get_registry()
+    created_registry = create_registry()
+
+    # Both should have same devices available
+    default_devices = {t.type_id for t in default_registry.list_all()}
+    created_devices = {t.type_id for t in created_registry.list_all()}
+
+    assert default_devices == created_devices
+    assert "bh1750" in created_devices
+
+
+def test_created_registry_can_create_devices():
+    """Test that created registries can create device instances."""
+    registry = create_registry()
+    device = registry.create("bh1750")
+    assert device is not None
+    assert "BH1750" in device.name


### PR DESCRIPTION
## Summary

Implements the solution proposed in #126 to make the device registry instantiable, enabling better testing patterns while maintaining full backward compatibility.

## Changes

### Core Changes
- **Lazy initialization**: Replaced global singleton with lazy-loaded default registry
- **`create_registry()`**: New function to create independent registry instances
- **`reset_default_registry()`**: New function to reset cached default instance for testing

### Documentation
- Updated module docstrings with examples for both default and isolated registry usage
- Added comprehensive docstrings for new functions
- Exported new functions from `devices` module

### Testing
- Added `tests/test_registry_isolation.py` with 6 tests demonstrating:
  - Independent registry creation
  - Default registry caching
  - Registry isolation
  - Reset functionality
  - Device creation from isolated registries

## Benefits

✅ **Better testability** - Isolated registries per test without shared state  
✅ **Dependency injection** - Components can accept registry as parameter  
✅ **Parallel testing** - No shared mutable state between tests  
✅ **Flexibility** - Multiple registries for different contexts  
✅ **Backward compatible** - All existing code continues to work unchanged

## Testing

- All 800 existing tests pass ✅
- 6 new tests added for isolation features ✅
- Ruff linting and formatting passed ✅

## Migration Path

No migration needed! Existing code using `get_registry()` works exactly as before:

```python
# Existing code - still works
from pinviz.devices import get_registry
registry = get_registry()
device = registry.create('bh1750')
```

New code can opt-in to isolated registries:

```python
# New pattern - isolated testing
from pinviz.devices import create_registry
test_registry = create_registry()
# Use independently without affecting global state
```

## Related

Fixes #126

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)