### PR TITLE
fix: correct IR LED Ring pin name from CTRL to EN

### DIFF
--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -267,7 +267,7 @@ connections:
     color: "#000000"  # Black
   - board_pin: 11
     device: "IR LED Ring"
-    device_pin: "CTRL"
+    device_pin: "EN"
     color: "#F44336"  # Red
 
 ```

--- a/examples/bh1750_ir_led.yaml
+++ b/examples/bh1750_ir_led.yaml
@@ -35,6 +35,6 @@ connections:
     color: "#000000"  # Black
   - board_pin: 11
     device: "IR LED Ring"
-    device_pin: "CTRL"
+    device_pin: "EN"
     color: "#F44336"  # Red
 

--- a/examples/bh1750_ir_led_python.py
+++ b/examples/bh1750_ir_led_python.py
@@ -25,7 +25,7 @@ connections = [
     # IR LED Ring (5V power + GPIO control)
     Connection(2, "IR LED Ring", "VCC", color=WireColor.RED),  # Pin 2 (5V) to VCC
     Connection(6, "IR LED Ring", "GND", color=WireColor.BLACK),  # Pin 6 (GND) to GND
-    Connection(11, "IR LED Ring", "CTRL", color=WireColor.RED),  # Pin 11 (GPIO17) to Control
+    Connection(11, "IR LED Ring", "EN", color=WireColor.RED),  # Pin 11 (GPIO17) to EN
 ]
 
 # Create diagram

--- a/examples/ir_led_ring.yaml
+++ b/examples/ir_led_ring.yaml
@@ -18,5 +18,5 @@ connections:
 
   - board_pin: 11   # GPIO17
     device: "IR_LED_Ring"
-    device_pin: "CTRL"
+    device_pin: "EN"
 

--- a/examples/ir_led_ring_python.py
+++ b/examples/ir_led_ring_python.py
@@ -12,7 +12,7 @@ led_ring = registry.create("ir_led_ring", num_leds=12)
 connections = [
     Connection(2, "IR LED Ring (12)", "VCC"),  # Pin 2 (5V) to VCC
     Connection(9, "IR LED Ring (12)", "GND"),  # Pin 9 (GND) to GND
-    Connection(11, "IR LED Ring (12)", "CTRL"),  # Pin 11 (GPIO17) to control pin
+    Connection(11, "IR LED Ring (12)", "EN"),  # Pin 11 (GPIO17) to EN
 ]
 
 # Create diagram

--- a/images/bh1750_ir_led.svg
+++ b/images/bh1750_ir_led.svg
@@ -1018,82 +1018,82 @@
 <text x="227.1" y="375.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">39</text>
 <circle cx="239.1" cy="374.2" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
 <text x="239.1" y="375.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">40</text>
-<path d="M 227.10,206.20 C 263.23,213.33 390.97,266.58 440.00,264.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,206.20 C 263.23,213.33 390.97,266.58 440.00,264.20" stroke="#F44336" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,206.20 C 263.23,209.02 390.97,296.14 440.00,295.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,206.20 C 263.23,209.02 390.97,296.14 440.00,295.20" stroke="#F44336" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="206.2" r="4.0" fill="white" />
 <circle cx="227.1" cy="206.2" r="3.0" fill="#F44336" />
-<path d="M 227.10,158.20 C 243.40,143.35 328.99,195.63 440.00,201.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,158.20 C 243.40,143.35 328.99,195.63 440.00,201.20" stroke="#4CAF50" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,158.20 C 248.83,142.27 376.57,213.89 440.00,219.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,158.20 C 248.83,142.27 376.57,213.89 440.00,219.20" stroke="#4CAF50" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="158.2" r="4.0" fill="white" />
 <circle cx="227.1" cy="158.2" r="3.0" fill="#4CAF50" />
-<path d="M 227.10,170.20 C 245.80,181.71 334.59,197.52 440.00,193.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,170.20 C 245.80,181.71 334.59,197.52 440.00,193.20" stroke="#2196F3" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,170.20 C 245.80,183.29 334.59,210.11 440.00,205.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,170.20 C 245.80,183.29 334.59,210.11 440.00,205.20" stroke="#2196F3" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="170.2" r="4.0" fill="white" />
 <circle cx="227.1" cy="170.2" r="3.0" fill="#2196F3" />
-<path d="M 227.10,194.20 C 248.20,275.59 340.19,215.72 440.00,185.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,194.20 C 248.20,275.59 340.19,215.72 440.00,185.20" stroke="#FFEB3B" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,194.20 C 248.20,269.00 340.19,219.25 440.00,191.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,194.20 C 248.20,269.00 340.19,219.25 440.00,191.20" stroke="#FFEB3B" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="194.2" r="4.0" fill="white" />
 <circle cx="227.1" cy="194.2" r="3.0" fill="#FFEB3B" />
-<path d="M 227.10,146.20 C 241.00,68.75 323.39,148.15 440.00,177.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,146.20 C 241.00,68.75 323.39,148.15 440.00,177.20" stroke="#FF9800" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,146.20 C 241.00,70.46 323.39,148.80 440.00,177.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,146.20 C 241.00,70.46 323.39,148.80 440.00,177.20" stroke="#FF9800" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="146.2" r="4.0" fill="white" />
 <circle cx="227.1" cy="146.2" r="3.0" fill="#FF9800" />
-<path d="M 239.10,170.20 C 267.23,215.57 387.77,289.32 440.00,274.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,170.20 C 267.23,215.57 387.77,289.32 440.00,274.20" stroke="#000000" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,170.20 C 267.23,216.76 387.77,320.72 440.00,305.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,170.20 C 267.23,216.76 387.77,320.72 440.00,305.20" stroke="#000000" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="170.2" r="4.0" fill="white" />
 <circle cx="239.1" cy="170.2" r="3.0" fill="#000000" />
-<path d="M 239.10,146.20 C 264.03,93.02 384.57,236.47 440.00,254.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 239.10,146.20 C 264.03,93.02 384.57,236.47 440.00,254.20" stroke="#F44336" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 239.10,146.20 C 264.03,99.08 384.57,269.49 440.00,285.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 239.10,146.20 C 264.03,99.08 384.57,269.49 440.00,285.20" stroke="#F44336" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="239.1" cy="146.2" r="4.0" fill="white" />
 <circle cx="239.1" cy="146.2" r="3.0" fill="#F44336" />
 <text x="490.0" y="162.2" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">BH1750 Light Sensor</text>
-<rect x="450.0" y="167.2" width="80.0" height="52.0" rx="5" ry="5" fill="#50E3C2" stroke="#333" stroke-width="2" opacity="0.9" />
-<text x="490.0" y="234.2" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">IR LED Ring</text>
-<rect x="450.0" y="239.2" width="80.0" height="50.0" rx="5" ry="5" fill="#E74C3C" stroke="#333" stroke-width="2" opacity="0.9" />
-<path d="M 440.00,264.20 L 457.00,264.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 440.00,264.20 L 457.00,264.20" stroke="#F44336" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
-<path d="M 440.00,201.20 L 457.00,201.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 440.00,201.20 L 457.00,201.20" stroke="#4CAF50" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
-<path d="M 440.00,193.20 L 457.00,193.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 440.00,193.20 L 457.00,193.20" stroke="#2196F3" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
-<path d="M 440.00,185.20 L 457.00,185.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 440.00,185.20 L 457.00,185.20" stroke="#FFEB3B" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<rect x="450.0" y="167.2" width="80.0" height="83.0" rx="5" ry="5" fill="#50E3C2" stroke="#333" stroke-width="2" opacity="0.9" />
+<text x="490.0" y="265.2" font-size="12.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">IR LED Ring</text>
+<rect x="450.0" y="270.2" width="80.0" height="50.0" rx="5" ry="5" fill="#E74C3C" stroke="#333" stroke-width="2" opacity="0.9" />
+<path d="M 440.00,295.20 L 457.00,295.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,295.20 L 457.00,295.20" stroke="#F44336" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,219.20 L 457.00,219.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,219.20 L 457.00,219.20" stroke="#4CAF50" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,205.20 L 457.00,205.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,205.20 L 457.00,205.20" stroke="#2196F3" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,191.20 L 457.00,191.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,191.20 L 457.00,191.20" stroke="#FFEB3B" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <path d="M 440.00,177.20 L 457.00,177.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
 <path d="M 440.00,177.20 L 457.00,177.20" stroke="#FF9800" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
-<path d="M 440.00,274.20 L 457.00,274.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 440.00,274.20 L 457.00,274.20" stroke="#000000" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
-<path d="M 440.00,254.20 L 457.00,254.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 440.00,254.20 L 457.00,254.20" stroke="#F44336" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,305.20 L 457.00,305.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,305.20 L 457.00,305.20" stroke="#000000" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,285.20 L 457.00,285.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,285.20 L 457.00,285.20" stroke="#F44336" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="455.0" cy="177.2" r="4.0" fill="white" opacity="0.8" />
 <circle cx="455.0" cy="177.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
 <rect x="461.0" y="172.2" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
 <text x="465.0" y="179.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
-<circle cx="455.0" cy="185.2" r="4.0" fill="white" opacity="0.8" />
-<circle cx="455.0" cy="185.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
-<rect x="461.0" y="180.2" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="187.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
-<circle cx="455.0" cy="193.2" r="4.0" fill="white" opacity="0.8" />
-<circle cx="455.0" cy="193.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
-<rect x="461.0" y="188.2" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="195.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SCL</text>
-<circle cx="455.0" cy="201.2" r="4.0" fill="white" opacity="0.8" />
-<circle cx="455.0" cy="201.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
-<rect x="461.0" y="196.2" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="203.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SDA</text>
-<circle cx="455.0" cy="209.2" r="4.0" fill="white" opacity="0.8" />
-<circle cx="455.0" cy="209.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
-<rect x="461.0" y="204.2" width="26.0" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="211.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">ADDR</text>
-<circle cx="455.0" cy="254.2" r="4.0" fill="white" opacity="0.8" />
-<circle cx="455.0" cy="254.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
-<rect x="461.0" y="249.2" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="256.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
-<circle cx="455.0" cy="264.2" r="4.0" fill="white" opacity="0.8" />
-<circle cx="455.0" cy="264.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
-<rect x="461.0" y="259.2" width="26.0" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="266.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">CTRL</text>
-<circle cx="455.0" cy="274.2" r="4.0" fill="white" opacity="0.8" />
-<circle cx="455.0" cy="274.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
-<rect x="461.0" y="269.2" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="276.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
+<circle cx="455.0" cy="191.2" r="4.0" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="191.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
+<rect x="461.0" y="186.2" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="193.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
+<circle cx="455.0" cy="205.2" r="4.0" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="205.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
+<rect x="461.0" y="200.2" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="207.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SCL</text>
+<circle cx="455.0" cy="219.2" r="4.0" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="219.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
+<rect x="461.0" y="214.2" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="221.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">SDA</text>
+<circle cx="455.0" cy="233.2" r="4.0" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="233.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
+<rect x="461.0" y="228.2" width="26.0" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="235.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">ADDR</text>
+<circle cx="455.0" cy="285.2" r="4.0" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="285.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
+<rect x="461.0" y="280.2" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="287.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
+<circle cx="455.0" cy="295.2" r="4.0" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="295.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
+<rect x="461.0" y="290.2" width="17.0" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="297.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">EN</text>
+<circle cx="455.0" cy="305.2" r="4.0" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="305.2" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
+<rect x="461.0" y="300.2" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="307.7" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
 </svg>

--- a/images/ir_led_ring.svg
+++ b/images/ir_led_ring.svg
@@ -1018,12 +1018,12 @@
 <text x="227.1" y="375.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">39</text>
 <circle cx="239.1" cy="374.2" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
 <text x="239.1" y="375.7" font-size="4.5" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">40</text>
-<path d="M 227.10,194.20 C 244.60,204.67 331.79,221.12 440.00,217.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,194.20 C 244.60,204.67 331.79,221.12 440.00,217.20" stroke="#000000" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,194.20 C 244.60,207.59 331.79,222.22 440.00,217.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,194.20 C 244.60,207.59 331.79,222.22 440.00,217.20" stroke="#000000" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="194.2" r="4.0" fill="white" />
 <circle cx="227.1" cy="194.2" r="3.0" fill="#000000" />
-<path d="M 227.10,206.20 C 247.00,210.93 337.39,208.98 440.00,207.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
-<path d="M 227.10,206.20 C 247.00,210.93 337.39,208.98 440.00,207.20" stroke="#808080" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 227.10,206.20 C 247.00,208.01 337.39,207.88 440.00,207.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 227.10,206.20 C 247.00,208.01 337.39,207.88 440.00,207.20" stroke="#808080" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
 <circle cx="227.1" cy="206.2" r="4.0" fill="white" />
 <circle cx="227.1" cy="206.2" r="3.0" fill="#808080" />
 <path d="M 239.10,146.20 C 254.43,129.10 374.97,191.50 440.00,197.20" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
@@ -1044,8 +1044,8 @@
 <text x="465.0" y="199.69999999999996" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">VCC</text>
 <circle cx="455.0" cy="207.19999999999996" r="4.0" fill="white" opacity="0.8" />
 <circle cx="455.0" cy="207.19999999999996" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
-<rect x="461.0" y="202.19999999999996" width="26.0" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
-<text x="465.0" y="209.69999999999996" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">CTRL</text>
+<rect x="461.0" y="202.19999999999996" width="17.0" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="209.69999999999996" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">EN</text>
 <circle cx="455.0" cy="217.19999999999996" r="4.0" fill="white" opacity="0.8" />
 <circle cx="455.0" cy="217.19999999999996" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
 <rect x="461.0" y="212.19999999999996" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />

--- a/src/pinviz/cli/commands/example.py
+++ b/src/pinviz/cli/commands/example.py
@@ -54,7 +54,7 @@ def create_ir_led_example() -> Diagram:
     connections = [
         Connection(2, "IR LED Ring (12)", "VCC"),  # 5V to VCC
         Connection(6, "IR LED Ring (12)", "GND"),  # GND to GND
-        Connection(7, "IR LED Ring (12)", "CTRL"),  # GPIO4 to CTRL
+        Connection(7, "IR LED Ring (12)", "EN"),  # GPIO4 to EN
     ]
 
     return Diagram(

--- a/src/pinviz/device_configs/leds/ir_led_ring.json
+++ b/src/pinviz/device_configs/leds/ir_led_ring.json
@@ -6,7 +6,7 @@
 
   "pins": [
     {"name": "VCC", "role": "5V"},
-    {"name": "CTRL", "role": "GPIO"},
+    {"name": "EN", "role": "GPIO"},
     {"name": "GND", "role": "GND"}
   ],
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -128,7 +128,7 @@ def test_ir_led_ring_has_correct_pins():
     pin_names = [pin.name for pin in device.pins]
     assert "VCC" in pin_names
     assert "GND" in pin_names
-    assert "CTRL" in pin_names
+    assert "EN" in pin_names
 
 
 def test_button_creation():


### PR DESCRIPTION
## Summary

Fixes the IR LED Ring device pin name from "CTRL" to "EN" to match the actual hardware label on the physical board.

## Changes

- **Device configuration**: Updated `ir_led_ring.json` pin definition
- **Examples**: Updated all YAML and Python API examples
- **Built-in commands**: Updated `pinviz example ir_led` command
- **Tests**: Updated unit tests to check for "EN" pin
- **Documentation**: Updated `docs/guide/examples.md`
- **Images**: Regenerated SVG diagrams with correct pin label

## Hardware Reference

The actual hardware uses "EN" (Enable) as the pin label, not "CTRL":
https://www.electrokit.com/led-ring-for-raspberry-pi-kamera-ir-leds

## Testing

✅ All 800 tests passed  
✅ Code quality checks passed (ruff)  
✅ All examples validate successfully  
✅ All examples render correctly  
✅ SVG images regenerated with correct label

🤖 Generated with [Claude Code](https://claude.com/claude-code)