### PR TITLE
feat: Expand device library to 40+ devices with communication modules

### DIFF
--- a/examples/ads1115_precision_adc.yaml
+++ b/examples/ads1115_precision_adc.yaml
@@ -1,0 +1,36 @@
+title: "ADS1115 16-bit Precision ADC"
+board: "raspberry_pi_5"
+show_legend: true
+
+devices:
+  - type: "ads1115"
+    name: "ADS1115"
+
+connections:
+  # Power
+  - board_pin: 1  # 3.3V
+    device: "ADS1115"
+    device_pin: "VDD"
+
+  - board_pin: 6  # Ground
+    device: "ADS1115"
+    device_pin: "GND"
+
+  # I2C Communication
+  - board_pin: 3  # I2C SDA (GPIO 2)
+    device: "ADS1115"
+    device_pin: "SDA"
+
+  - board_pin: 5  # I2C SCL (GPIO 3)
+    device: "ADS1115"
+    device_pin: "SCL"
+
+  # Address pin to ground for default address (0x48)
+  - board_pin: 9  # Ground
+    device: "ADS1115"
+    device_pin: "ADDR"
+
+  # Alert/Ready pin (optional - to GPIO)
+  - board_pin: 11  # GPIO 17
+    device: "ADS1115"
+    device_pin: "ALRT"

--- a/examples/ds3231_rtc.yaml
+++ b/examples/ds3231_rtc.yaml
@@ -1,0 +1,31 @@
+title: "DS3231 Real-Time Clock"
+board: "raspberry_pi_5"
+show_legend: true
+
+devices:
+  - type: "ds3231"
+    name: "DS3231"
+
+connections:
+  # Power
+  - board_pin: 1  # 3.3V
+    device: "DS3231"
+    device_pin: "VCC"
+
+  - board_pin: 6  # Ground
+    device: "DS3231"
+    device_pin: "GND"
+
+  # I2C Communication
+  - board_pin: 3  # I2C SDA (GPIO 2)
+    device: "DS3231"
+    device_pin: "SDA"
+
+  - board_pin: 5  # I2C SCL (GPIO 3)
+    device: "DS3231"
+    device_pin: "SCL"
+
+  # Square wave output (optional - to GPIO)
+  - board_pin: 11  # GPIO 17
+    device: "DS3231"
+    device_pin: "SQW"

--- a/examples/esp8266_wifi.yaml
+++ b/examples/esp8266_wifi.yaml
@@ -1,0 +1,36 @@
+title: "ESP8266 WiFi Module"
+board: "raspberry_pi_5"
+
+devices:
+  - type: "esp8266"
+    name: "ESP8266"
+
+connections:
+  # Power connections
+  - board_pin: 1    # 3.3V (VCC)
+    device: "ESP8266"
+    device_pin: "VCC"
+
+  - board_pin: 1    # 3.3V (CH_PD - chip enable, must be high)
+    device: "ESP8266"
+    device_pin: "CH_PD"
+
+  - board_pin: 6    # GND
+    device: "ESP8266"
+    device_pin: "GND"
+
+  # UART connections (note: TX->RX, RX->TX crossover)
+  - board_pin: 8    # UART TX (GPIO14)
+    device: "ESP8266"
+    device_pin: "RX"
+
+  - board_pin: 10   # UART RX (GPIO15)
+    device: "ESP8266"
+    device_pin: "TX"
+
+  # Optional: Reset pin
+  - board_pin: 16   # GPIO23
+    device: "ESP8266"
+    device_pin: "RST"
+
+show_legend: true

--- a/examples/hc05_bluetooth.yaml
+++ b/examples/hc05_bluetooth.yaml
@@ -1,0 +1,32 @@
+title: "HC-05 Bluetooth Module"
+board: "raspberry_pi_5"
+
+devices:
+  - type: "hc05"
+    name: "HC-05"
+
+connections:
+  # Power connections (HC-05 needs 5V)
+  - board_pin: 2    # 5V
+    device: "HC-05"
+    device_pin: "VCC"
+
+  - board_pin: 6    # GND
+    device: "HC-05"
+    device_pin: "GND"
+
+  # UART connections (note: TXD->RX, RXD->TX crossover)
+  - board_pin: 8    # UART TX (GPIO14)
+    device: "HC-05"
+    device_pin: "RXD"
+
+  - board_pin: 10   # UART RX (GPIO15)
+    device: "HC-05"
+    device_pin: "TXD"
+
+  # Optional: KEY pin for AT command mode
+  - board_pin: 16   # GPIO23
+    device: "HC-05"
+    device_pin: "KEY"
+
+show_legend: true

--- a/examples/ina219_power_monitor.yaml
+++ b/examples/ina219_power_monitor.yaml
@@ -1,0 +1,27 @@
+title: "INA219 Current/Power Monitor"
+board: "raspberry_pi_5"
+
+devices:
+  - type: "ina219"
+    name: "INA219"
+
+connections:
+  # Power connections
+  - board_pin: 1    # 3.3V
+    device: "INA219"
+    device_pin: "VCC"
+
+  - board_pin: 6    # GND
+    device: "INA219"
+    device_pin: "GND"
+
+  # I2C connections
+  - board_pin: 3    # I2C SDA (GPIO2)
+    device: "INA219"
+    device_pin: "SDA"
+
+  - board_pin: 5    # I2C SCL (GPIO3)
+    device: "INA219"
+    device_pin: "SCL"
+
+show_legend: true

--- a/examples/l298n_dual_motor.yaml
+++ b/examples/l298n_dual_motor.yaml
@@ -1,0 +1,39 @@
+title: "L298N Dual Motor Driver"
+board: "raspberry_pi_5"
+show_legend: true
+
+devices:
+  - type: "l298n"
+    name: "L298N"
+
+connections:
+  # Ground
+  - board_pin: 6  # Ground
+    device: "L298N"
+    device_pin: "GND"
+
+  # Motor A Control
+  - board_pin: 12  # GPIO 18 (PWM)
+    device: "L298N"
+    device_pin: "ENA"
+
+  - board_pin: 11  # GPIO 17
+    device: "L298N"
+    device_pin: "IN1"
+
+  - board_pin: 13  # GPIO 27
+    device: "L298N"
+    device_pin: "IN2"
+
+  # Motor B Control
+  - board_pin: 15  # GPIO 22
+    device: "L298N"
+    device_pin: "IN3"
+
+  - board_pin: 16  # GPIO 23
+    device: "L298N"
+    device_pin: "IN4"
+
+  - board_pin: 32  # GPIO 12 (PWM)
+    device: "L298N"
+    device_pin: "ENB"

--- a/examples/lcd1602_display.yaml
+++ b/examples/lcd1602_display.yaml
@@ -1,0 +1,26 @@
+title: "LCD1602 16x2 Character Display"
+board: "raspberry_pi_5"
+show_legend: true
+
+devices:
+  - type: "lcd1602"
+    name: "LCD1602"
+
+connections:
+  # Power (5V for best backlight brightness)
+  - board_pin: 2  # 5V
+    device: "LCD1602"
+    device_pin: "VCC"
+
+  - board_pin: 6  # Ground
+    device: "LCD1602"
+    device_pin: "GND"
+
+  # I2C Communication (via PCF8574 backpack)
+  - board_pin: 3  # I2C SDA (GPIO 2)
+    device: "LCD1602"
+    device_pin: "SDA"
+
+  - board_pin: 5  # I2C SCL (GPIO 3)
+    device: "LCD1602"
+    device_pin: "SCL"

--- a/examples/mcp3008_adc.yaml
+++ b/examples/mcp3008_adc.yaml
@@ -1,0 +1,42 @@
+title: "MCP3008 8-Channel ADC"
+board: "raspberry_pi_5"
+show_legend: true
+
+devices:
+  - type: "mcp3008"
+    name: "MCP3008"
+
+connections:
+  # Power
+  - board_pin: 17  # 3.3V
+    device: "MCP3008"
+    device_pin: "VDD"
+
+  - board_pin: 17  # 3.3V for reference
+    device: "MCP3008"
+    device_pin: "VREF"
+
+  - board_pin: 20  # Ground
+    device: "MCP3008"
+    device_pin: "AGND"
+
+  - board_pin: 20  # Ground
+    device: "MCP3008"
+    device_pin: "DGND"
+
+  # SPI Communication
+  - board_pin: 23  # SPI SCLK (GPIO 11)
+    device: "MCP3008"
+    device_pin: "CLK"
+
+  - board_pin: 21  # SPI MISO (GPIO 9)
+    device: "MCP3008"
+    device_pin: "DOUT"
+
+  - board_pin: 19  # SPI MOSI (GPIO 10)
+    device: "MCP3008"
+    device_pin: "DIN"
+
+  - board_pin: 24  # SPI CE0 (GPIO 8)
+    device: "MCP3008"
+    device_pin: "CS"

--- a/examples/mpu6050_imu.yaml
+++ b/examples/mpu6050_imu.yaml
@@ -1,0 +1,26 @@
+title: "MPU6050 6-Axis IMU"
+board: "raspberry_pi_5"
+show_legend: true
+
+devices:
+  - type: "mpu6050"
+    name: "MPU6050"
+
+connections:
+  # Power
+  - board_pin: 1  # 3.3V
+    device: "MPU6050"
+    device_pin: "VCC"
+
+  - board_pin: 6  # Ground
+    device: "MPU6050"
+    device_pin: "GND"
+
+  # I2C Communication
+  - board_pin: 3  # I2C SDA (GPIO 2)
+    device: "MPU6050"
+    device_pin: "SDA"
+
+  - board_pin: 5  # I2C SCL (GPIO 3)
+    device: "MPU6050"
+    device_pin: "SCL"

--- a/examples/nrf24l01_wireless.yaml
+++ b/examples/nrf24l01_wireless.yaml
@@ -1,0 +1,44 @@
+title: "nRF24L01+ Wireless Transceiver"
+board: "raspberry_pi_5"
+
+devices:
+  - type: "nrf24l01"
+    name: "nRF24L01+"
+
+connections:
+  # Power connections
+  - board_pin: 1    # 3.3V
+    device: "nRF24L01+"
+    device_pin: "VCC"
+
+  - board_pin: 6    # GND
+    device: "nRF24L01+"
+    device_pin: "GND"
+
+  # SPI connections
+  - board_pin: 23   # SPI0 SCLK (GPIO11)
+    device: "nRF24L01+"
+    device_pin: "SCK"
+
+  - board_pin: 19   # SPI0 MOSI (GPIO10)
+    device: "nRF24L01+"
+    device_pin: "MOSI"
+
+  - board_pin: 21   # SPI0 MISO (GPIO9)
+    device: "nRF24L01+"
+    device_pin: "MISO"
+
+  - board_pin: 24   # SPI0 CE0 (GPIO8)
+    device: "nRF24L01+"
+    device_pin: "CSN"
+
+  # Control pins
+  - board_pin: 22   # GPIO25
+    device: "nRF24L01+"
+    device_pin: "CE"
+
+  - board_pin: 18   # GPIO24 (optional IRQ)
+    device: "nRF24L01+"
+    device_pin: "IRQ"
+
+show_legend: true

--- a/examples/rc522_rfid.yaml
+++ b/examples/rc522_rfid.yaml
@@ -1,0 +1,40 @@
+title: "RC522 RFID Reader"
+board: "raspberry_pi_5"
+
+devices:
+  - type: "rc522"
+    name: "RC522"
+
+connections:
+  # Power connections
+  - board_pin: 1    # 3.3V
+    device: "RC522"
+    device_pin: "VCC"
+
+  - board_pin: 6    # GND
+    device: "RC522"
+    device_pin: "GND"
+
+  # SPI connections
+  - board_pin: 23   # SPI0 SCLK (GPIO11)
+    device: "RC522"
+    device_pin: "SCK"
+
+  - board_pin: 19   # SPI0 MOSI (GPIO10)
+    device: "RC522"
+    device_pin: "MOSI"
+
+  - board_pin: 21   # SPI0 MISO (GPIO9)
+    device: "RC522"
+    device_pin: "MISO"
+
+  - board_pin: 24   # SPI0 CE0 (GPIO8)
+    device: "RC522"
+    device_pin: "SDA"
+
+  # Control pins
+  - board_pin: 22   # GPIO25
+    device: "RC522"
+    device_pin: "RST"
+
+show_legend: true

--- a/examples/sg90_servo.yaml
+++ b/examples/sg90_servo.yaml
@@ -1,0 +1,22 @@
+title: "SG90 Servo Motor"
+board: "raspberry_pi_5"
+show_legend: true
+
+devices:
+  - type: "sg90"
+    name: "Servo"
+
+connections:
+  # Power (5V recommended for servo)
+  - board_pin: 2  # 5V
+    device: "Servo"
+    device_pin: "VCC"
+
+  - board_pin: 6  # Ground
+    device: "Servo"
+    device_pin: "GND"
+
+  # PWM Control Signal
+  - board_pin: 12  # GPIO 18 (PWM0)
+    device: "Servo"
+    device_pin: "Signal"

--- a/examples/sim800l_gsm.yaml
+++ b/examples/sim800l_gsm.yaml
@@ -1,0 +1,32 @@
+title: "SIM800L GSM Module"
+board: "raspberry_pi_5"
+
+devices:
+  - type: "sim800l"
+    name: "SIM800L"
+
+connections:
+  # Power connections (SIM800L needs 5V but check your specific module)
+  - board_pin: 2    # 5V
+    device: "SIM800L"
+    device_pin: "VCC"
+
+  - board_pin: 6    # GND
+    device: "SIM800L"
+    device_pin: "GND"
+
+  # UART connections (note: TXD->RX, RXD->TX crossover)
+  - board_pin: 8    # UART TX (GPIO14)
+    device: "SIM800L"
+    device_pin: "RXD"
+
+  - board_pin: 10   # UART RX (GPIO15)
+    device: "SIM800L"
+    device_pin: "TXD"
+
+  # Optional: Reset pin
+  - board_pin: 16   # GPIO23
+    device: "SIM800L"
+    device_pin: "RST"
+
+show_legend: true

--- a/examples/st7735_tft.yaml
+++ b/examples/st7735_tft.yaml
@@ -1,0 +1,44 @@
+title: "ST7735 1.8\" Color TFT Display"
+board: "raspberry_pi_5"
+show_legend: true
+
+devices:
+  - type: "st7735"
+    name: "ST7735"
+
+connections:
+  # Power
+  - board_pin: 1  # 3.3V
+    device: "ST7735"
+    device_pin: "VCC"
+
+  - board_pin: 6  # Ground
+    device: "ST7735"
+    device_pin: "GND"
+
+  # Backlight (connect to 3.3V or PWM for dimming)
+  - board_pin: 17  # 3.3V
+    device: "ST7735"
+    device_pin: "LED"
+
+  # SPI Communication
+  - board_pin: 19  # SPI MOSI (GPIO 10)
+    device: "ST7735"
+    device_pin: "MOSI"
+
+  - board_pin: 23  # SPI SCLK (GPIO 11)
+    device: "ST7735"
+    device_pin: "SCLK"
+
+  - board_pin: 24  # SPI CE0 (GPIO 8)
+    device: "ST7735"
+    device_pin: "CS"
+
+  # Control pins
+  - board_pin: 11  # GPIO 17 (Data/Command)
+    device: "ST7735"
+    device_pin: "DC"
+
+  - board_pin: 13  # GPIO 27 (Reset)
+    device: "ST7735"
+    device_pin: "RESET"

--- a/examples/sx1278_lora.yaml
+++ b/examples/sx1278_lora.yaml
@@ -1,0 +1,44 @@
+title: "SX1278 LoRa Transceiver"
+board: "raspberry_pi_5"
+
+devices:
+  - type: "sx1278"
+    name: "LoRa"
+
+connections:
+  # Power connections
+  - board_pin: 1    # 3.3V
+    device: "LoRa"
+    device_pin: "VCC"
+
+  - board_pin: 6    # GND
+    device: "LoRa"
+    device_pin: "GND"
+
+  # SPI connections
+  - board_pin: 23   # SPI0 SCLK (GPIO11)
+    device: "LoRa"
+    device_pin: "SCK"
+
+  - board_pin: 19   # SPI0 MOSI (GPIO10)
+    device: "LoRa"
+    device_pin: "MOSI"
+
+  - board_pin: 21   # SPI0 MISO (GPIO9)
+    device: "LoRa"
+    device_pin: "MISO"
+
+  - board_pin: 24   # SPI0 CE0 (GPIO8)
+    device: "LoRa"
+    device_pin: "NSS"
+
+  # Control pins
+  - board_pin: 22   # GPIO25
+    device: "LoRa"
+    device_pin: "RESET"
+
+  - board_pin: 18   # GPIO24
+    device: "LoRa"
+    device_pin: "DIO0"
+
+show_legend: true

--- a/examples/tb6612fng_motor.yaml
+++ b/examples/tb6612fng_motor.yaml
@@ -1,0 +1,48 @@
+title: "TB6612FNG Compact Motor Driver"
+board: "raspberry_pi_5"
+show_legend: true
+
+devices:
+  - type: "tb6612fng"
+    name: "TB6612FNG"
+
+connections:
+  # Power
+  - board_pin: 1  # 3.3V (logic)
+    device: "TB6612FNG"
+    device_pin: "VCC"
+
+  - board_pin: 6  # Ground
+    device: "TB6612FNG"
+    device_pin: "GND"
+
+  # Standby (must be HIGH to enable)
+  - board_pin: 11  # GPIO 17
+    device: "TB6612FNG"
+    device_pin: "STBY"
+
+  # Motor A Control
+  - board_pin: 12  # GPIO 18 (PWM)
+    device: "TB6612FNG"
+    device_pin: "PWMA"
+
+  - board_pin: 13  # GPIO 27
+    device: "TB6612FNG"
+    device_pin: "AIN1"
+
+  - board_pin: 15  # GPIO 22
+    device: "TB6612FNG"
+    device_pin: "AIN2"
+
+  # Motor B Control
+  - board_pin: 16  # GPIO 23
+    device: "TB6612FNG"
+    device_pin: "BIN1"
+
+  - board_pin: 18  # GPIO 24
+    device: "TB6612FNG"
+    device_pin: "BIN2"
+
+  - board_pin: 32  # GPIO 12 (PWM)
+    device: "TB6612FNG"
+    device_pin: "PWMB"

--- a/examples/uln2003_stepper.yaml
+++ b/examples/uln2003_stepper.yaml
@@ -1,0 +1,34 @@
+title: "28BYJ-48 Stepper Motor with ULN2003 Driver"
+board: "raspberry_pi_5"
+show_legend: true
+
+devices:
+  - type: "uln2003"
+    name: "Stepper"
+
+connections:
+  # Power
+  - board_pin: 2  # 5V
+    device: "Stepper"
+    device_pin: "VCC"
+
+  - board_pin: 6  # Ground
+    device: "Stepper"
+    device_pin: "GND"
+
+  # Stepper Control (4-phase)
+  - board_pin: 11  # GPIO 17
+    device: "Stepper"
+    device_pin: "IN1"
+
+  - board_pin: 13  # GPIO 27
+    device: "Stepper"
+    device_pin: "IN2"
+
+  - board_pin: 15  # GPIO 22
+    device: "Stepper"
+    device_pin: "IN3"
+
+  - board_pin: 16  # GPIO 23
+    device: "Stepper"
+    device_pin: "IN4"

--- a/src/pinviz/device_configs/actuators/l298n.json
+++ b/src/pinviz/device_configs/actuators/l298n.json
@@ -1,0 +1,80 @@
+{
+  "id": "l298n",
+  "name": "L298N Motor Driver",
+  "category": "actuators",
+  "description": "Dual H-bridge motor driver module for DC motors and stepper motors",
+  "pins": [
+    {
+      "name": "12V",
+      "role": "5V",
+      "side": "left",
+      "optional": true
+    },
+    {
+      "name": "GND",
+      "role": "GND",
+      "side": "left"
+    },
+    {
+      "name": "5V",
+      "role": "5V",
+      "side": "left",
+      "optional": true
+    },
+    {
+      "name": "ENA",
+      "role": "PWM",
+      "side": "left"
+    },
+    {
+      "name": "IN1",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "IN2",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "IN3",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "IN4",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "ENB",
+      "role": "PWM",
+      "side": "left"
+    },
+    {
+      "name": "OUT1",
+      "role": "5V",
+      "side": "right"
+    },
+    {
+      "name": "OUT2",
+      "role": "5V",
+      "side": "right"
+    },
+    {
+      "name": "OUT3",
+      "role": "5V",
+      "side": "right"
+    },
+    {
+      "name": "OUT4",
+      "role": "5V",
+      "side": "right"
+    }
+  ],
+  "display": {
+    "width": 100.0
+  },
+  "datasheet_url": "https://www.sparkfun.com/datasheets/Robotics/L298_H_Bridge.pdf",
+  "notes": "Dual H-bridge driver. ENA/ENB enable motor A/B (PWM for speed control). IN1-IN2 control motor A direction, IN3-IN4 control motor B. Supports 5-35V motors up to 2A per channel. OUT1-OUT2 connect to motor A, OUT3-OUT4 to motor B."
+}

--- a/src/pinviz/device_configs/actuators/sg90.json
+++ b/src/pinviz/device_configs/actuators/sg90.json
@@ -1,0 +1,22 @@
+{
+  "id": "sg90",
+  "name": "SG90 Servo Motor",
+  "category": "actuators",
+  "description": "Micro servo motor with 180° rotation, controlled by PWM signal",
+  "pins": [
+    {
+      "name": "GND",
+      "role": "GND"
+    },
+    {
+      "name": "VCC",
+      "role": "5V"
+    },
+    {
+      "name": "Signal",
+      "role": "PWM"
+    }
+  ],
+  "datasheet_url": "http://www.towerpro.com.tw/product/sg90-7/",
+  "notes": "Micro servo with 180° rotation. Control via PWM: 1ms pulse = 0°, 1.5ms = 90°, 2ms = 180°. Operating voltage: 4.8-6V. Torque: 1.8 kg/cm at 4.8V. Speed: 0.1s/60° at 4.8V. Use external power supply for multiple servos."
+}

--- a/src/pinviz/device_configs/actuators/tb6612fng.json
+++ b/src/pinviz/device_configs/actuators/tb6612fng.json
@@ -1,0 +1,83 @@
+{
+  "id": "tb6612fng",
+  "name": "TB6612FNG Motor Driver",
+  "category": "actuators",
+  "description": "Compact dual motor driver with PWM control and standby mode",
+  "pins": [
+    {
+      "name": "VM",
+      "role": "5V",
+      "side": "left"
+    },
+    {
+      "name": "VCC",
+      "role": "3V3",
+      "side": "left"
+    },
+    {
+      "name": "GND",
+      "role": "GND",
+      "side": "left"
+    },
+    {
+      "name": "STBY",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "PWMA",
+      "role": "PWM",
+      "side": "left"
+    },
+    {
+      "name": "AIN1",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "AIN2",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "BIN1",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "BIN2",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "PWMB",
+      "role": "PWM",
+      "side": "left"
+    },
+    {
+      "name": "A01",
+      "role": "5V",
+      "side": "right"
+    },
+    {
+      "name": "A02",
+      "role": "5V",
+      "side": "right"
+    },
+    {
+      "name": "B01",
+      "role": "5V",
+      "side": "right"
+    },
+    {
+      "name": "B02",
+      "role": "5V",
+      "side": "right"
+    }
+  ],
+  "display": {
+    "width": 90.0
+  },
+  "datasheet_url": "https://www.sparkfun.com/datasheets/Robotics/TB6612FNG.pdf",
+  "notes": "Dual motor driver. VM is motor voltage (4.5-13.5V), VCC is logic voltage (2.7-5.5V). STBY must be HIGH to enable (built-in pull-down). PWMA/PWMB control speed, AIN1-AIN2/BIN1-BIN2 control direction. Supports up to 1.2A per channel (3.2A peak). More efficient than L298N."
+}

--- a/src/pinviz/device_configs/actuators/uln2003.json
+++ b/src/pinviz/device_configs/actuators/uln2003.json
@@ -1,0 +1,40 @@
+{
+  "id": "uln2003",
+  "name": "28BYJ-48 Stepper with ULN2003",
+  "category": "actuators",
+  "description": "5V stepper motor with ULN2003 Darlington driver board",
+  "pins": [
+    {
+      "name": "IN1",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "IN2",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "IN3",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "IN4",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "VCC",
+      "role": "5V",
+      "side": "left"
+    },
+    {
+      "name": "GND",
+      "role": "GND",
+      "side": "left"
+    }
+  ],
+  "datasheet_url": "https://components101.com/motors/28byj-48-stepper-motor",
+  "notes": "28BYJ-48 stepper motor with ULN2003 driver board. 5V unipolar stepper with 4 coils. Stride angle: 5.625°/64 (with gear reduction: 2048 steps/revolution). Sequence for full-step: IN1-IN3-IN2-IN4 (or use half-step for smoother motion). Max speed: ~15 RPM."
+}

--- a/src/pinviz/device_configs/communication/esp8266.json
+++ b/src/pinviz/device_configs/communication/esp8266.json
@@ -1,0 +1,20 @@
+{
+  "id": "esp8266",
+  "name": "ESP8266 WiFi Module",
+  "category": "communication",
+  "description": "WiFi module with UART AT command interface",
+
+  "pins": [
+    {"name": "VCC", "role": "3V3"},
+    {"name": "GND", "role": "GND"},
+    {"name": "TX", "role": "UART_TX"},
+    {"name": "RX", "role": "UART_RX"},
+    {"name": "CH_PD", "role": "3V3"},
+    {"name": "RST", "role": "GPIO", "optional": true},
+    {"name": "GPIO0", "role": "GPIO", "optional": true},
+    {"name": "GPIO2", "role": "GPIO", "optional": true}
+  ],
+
+  "datasheet_url": "https://www.espressif.com/sites/default/files/documentation/0a-esp8266ex_datasheet_en.pdf",
+  "notes": "WiFi module with AT commands. CH_PD (chip enable) must be high. GPIO0 low for firmware flash mode. RST for reset. Requires stable 3.3V supply with good current capability."
+}

--- a/src/pinviz/device_configs/communication/hc05.json
+++ b/src/pinviz/device_configs/communication/hc05.json
@@ -1,0 +1,18 @@
+{
+  "id": "hc05",
+  "name": "HC-05 Bluetooth Module",
+  "category": "communication",
+  "description": "Bluetooth 2.0 SPP module with UART interface",
+
+  "pins": [
+    {"name": "VCC", "role": "5V"},
+    {"name": "GND", "role": "GND"},
+    {"name": "TXD", "role": "UART_TX"},
+    {"name": "RXD", "role": "UART_RX"},
+    {"name": "KEY", "role": "GPIO", "optional": true},
+    {"name": "STATE", "role": "GPIO", "optional": true}
+  ],
+
+  "datasheet_url": "https://www.electronicwings.com/sensors-modules/bluetooth-module-hc-05-",
+  "notes": "Bluetooth 2.0 module with SPP profile. TXD/RXD are 3.3V logic. Use voltage divider on RXD to Pi. KEY pin enables AT command mode. STATE indicates connection status."
+}

--- a/src/pinviz/device_configs/communication/mcp2515.json
+++ b/src/pinviz/device_configs/communication/mcp2515.json
@@ -1,0 +1,19 @@
+{
+  "id": "mcp2515",
+  "name": "MCP2515 CAN Bus Controller",
+  "category": "communication",
+  "description": "CAN bus controller with SPI interface and TJA1050 transceiver",
+
+  "pins": [
+    {"name": "VCC", "role": "5V"},
+    {"name": "GND", "role": "GND"},
+    {"name": "SCK", "role": "SPI_SCLK"},
+    {"name": "SI", "role": "SPI_MOSI"},
+    {"name": "SO", "role": "SPI_MISO"},
+    {"name": "CS", "role": "SPI_CE0"},
+    {"name": "INT", "role": "GPIO"}
+  ],
+
+  "datasheet_url": "https://www.microchip.com/en-us/product/MCP2515",
+  "notes": "CAN bus controller for automotive/industrial communication. INT indicates received messages or errors. Requires CAN-H and CAN-L external connections. Operates at up to 1Mbps."
+}

--- a/src/pinviz/device_configs/communication/nrf24l01.json
+++ b/src/pinviz/device_configs/communication/nrf24l01.json
@@ -1,0 +1,20 @@
+{
+  "id": "nrf24l01",
+  "name": "nRF24L01+ Wireless Transceiver",
+  "category": "communication",
+  "description": "2.4GHz wireless transceiver module with SPI interface",
+
+  "pins": [
+    {"name": "VCC", "role": "3V3"},
+    {"name": "GND", "role": "GND"},
+    {"name": "CE", "role": "GPIO"},
+    {"name": "CSN", "role": "SPI_CE0"},
+    {"name": "SCK", "role": "SPI_SCLK"},
+    {"name": "MOSI", "role": "SPI_MOSI"},
+    {"name": "MISO", "role": "SPI_MISO"},
+    {"name": "IRQ", "role": "GPIO", "optional": true}
+  ],
+
+  "datasheet_url": "https://www.sparkfun.com/datasheets/Components/SMD/nRF24L01Pluss_Preliminary_Product_Specification_v1_0.pdf",
+  "notes": "2.4GHz transceiver with 250kbps-2Mbps data rates. Requires 3.3V power. CE pin controls TX/RX mode. CSN is chip select. IRQ indicates data ready/TX complete."
+}

--- a/src/pinviz/device_configs/communication/rc522.json
+++ b/src/pinviz/device_configs/communication/rc522.json
@@ -1,0 +1,20 @@
+{
+  "id": "rc522",
+  "name": "RC522 RFID Reader",
+  "category": "communication",
+  "description": "13.56MHz RFID/NFC reader module with SPI interface",
+
+  "pins": [
+    {"name": "VCC", "role": "3V3"},
+    {"name": "GND", "role": "GND"},
+    {"name": "SCK", "role": "SPI_SCLK"},
+    {"name": "MOSI", "role": "SPI_MOSI"},
+    {"name": "MISO", "role": "SPI_MISO"},
+    {"name": "SDA", "role": "SPI_CE0"},
+    {"name": "RST", "role": "GPIO"},
+    {"name": "IRQ", "role": "GPIO", "optional": true}
+  ],
+
+  "datasheet_url": "https://www.nxp.com/docs/en/data-sheet/MFRC522.pdf",
+  "notes": "RFID reader for Mifare cards. SDA pin is chip select (not I2C). RST for reset. IRQ indicates card detection. Supports ISO/IEC 14443 A/MIFARE."
+}

--- a/src/pinviz/device_configs/communication/sim800l.json
+++ b/src/pinviz/device_configs/communication/sim800l.json
@@ -1,0 +1,18 @@
+{
+  "id": "sim800l",
+  "name": "SIM800L GSM Module",
+  "category": "communication",
+  "description": "GSM/GPRS cellular module with UART interface",
+
+  "pins": [
+    {"name": "VCC", "role": "5V"},
+    {"name": "GND", "role": "GND"},
+    {"name": "TXD", "role": "UART_TX"},
+    {"name": "RXD", "role": "UART_RX"},
+    {"name": "RST", "role": "GPIO", "optional": true},
+    {"name": "DTR", "role": "GPIO", "optional": true}
+  ],
+
+  "datasheet_url": "https://www.simcom.com/product/SIM800L.html",
+  "notes": "GSM/GPRS module for cellular communication and SMS. Requires 3.4-4.4V stable supply with high current (2A burst). Use AT commands via UART. RST for reset. DTR for sleep control."
+}

--- a/src/pinviz/device_configs/communication/sx1278.json
+++ b/src/pinviz/device_configs/communication/sx1278.json
@@ -1,0 +1,22 @@
+{
+  "id": "sx1278",
+  "name": "SX1278 LoRa Module",
+  "category": "communication",
+  "description": "Long range LoRa transceiver with SPI interface",
+
+  "pins": [
+    {"name": "VCC", "role": "3V3"},
+    {"name": "GND", "role": "GND"},
+    {"name": "SCK", "role": "SPI_SCLK"},
+    {"name": "MOSI", "role": "SPI_MOSI"},
+    {"name": "MISO", "role": "SPI_MISO"},
+    {"name": "NSS", "role": "SPI_CE0"},
+    {"name": "RESET", "role": "GPIO"},
+    {"name": "DIO0", "role": "GPIO"},
+    {"name": "DIO1", "role": "GPIO", "optional": true},
+    {"name": "DIO2", "role": "GPIO", "optional": true}
+  ],
+
+  "datasheet_url": "https://www.semtech.com/products/wireless-rf/lora-core/sx1278",
+  "notes": "LoRa transceiver for long range communication (up to 10km). NSS is chip select. RESET for module reset. DIO0 indicates RX/TX done. Operates on 433/868/915 MHz bands."
+}

--- a/src/pinviz/device_configs/displays/lcd1602.json
+++ b/src/pinviz/device_configs/displays/lcd1602.json
@@ -1,0 +1,27 @@
+{
+  "id": "lcd1602",
+  "name": "LCD1602 Character Display",
+  "category": "displays",
+  "description": "16x2 character LCD display with I2C interface (PCF8574 backpack)",
+  "pins": [
+    {
+      "name": "VCC",
+      "role": "5V"
+    },
+    {
+      "name": "GND",
+      "role": "GND"
+    },
+    {
+      "name": "SDA",
+      "role": "I2C_SDA"
+    },
+    {
+      "name": "SCL",
+      "role": "I2C_SCL"
+    }
+  ],
+  "i2c_address": "0x27",
+  "datasheet_url": "https://www.sparkfun.com/datasheets/LCD/HD44780.pdf",
+  "notes": "16 columns x 2 rows character LCD with I2C backpack (PCF8574). Common I2C addresses: 0x27 or 0x3F. 5V recommended for backlight brightness. HD44780 compatible. Supports custom characters and backlight control."
+}

--- a/src/pinviz/device_configs/displays/st7735.json
+++ b/src/pinviz/device_configs/displays/st7735.json
@@ -1,0 +1,54 @@
+{
+  "id": "st7735",
+  "name": "ST7735 TFT Display",
+  "category": "displays",
+  "description": "1.8 inch 128x160 color TFT LCD display with SPI interface",
+  "pins": [
+    {
+      "name": "VCC",
+      "role": "3V3",
+      "side": "left"
+    },
+    {
+      "name": "GND",
+      "role": "GND",
+      "side": "left"
+    },
+    {
+      "name": "CS",
+      "role": "SPI_CE0",
+      "side": "left"
+    },
+    {
+      "name": "RESET",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "DC",
+      "role": "GPIO",
+      "side": "left"
+    },
+    {
+      "name": "MOSI",
+      "role": "SPI_MOSI",
+      "side": "left"
+    },
+    {
+      "name": "SCLK",
+      "role": "SPI_SCLK",
+      "side": "left"
+    },
+    {
+      "name": "LED",
+      "role": "3V3",
+      "side": "left",
+      "optional": true
+    }
+  ],
+  "display": {
+    "width": 70.0
+  },
+  "datasheet_url": "https://www.crystalfontz.com/controllers/Sitronix/ST7735R/319",
+  "notes": "1.8\" 128x160 pixel color TFT display. SPI interface with DC (data/command) and RESET pins. LED pin for backlight control (can connect to 3.3V or PWM). Supports 65K colors (16-bit RGB565). Popular for small graphic displays and gauges."
+}

--- a/src/pinviz/device_configs/sensors/ads1115.json
+++ b/src/pinviz/device_configs/sensors/ads1115.json
@@ -1,0 +1,23 @@
+{
+  "id": "ads1115",
+  "name": "ADS1115 ADC",
+  "category": "sensors",
+  "description": "16-bit precision analog-to-digital converter with programmable gain amplifier and I2C interface",
+
+  "pins": [
+    {"name": "VDD", "role": "3V3"},
+    {"name": "GND", "role": "GND"},
+    {"name": "SCL", "role": "I2C_SCL"},
+    {"name": "SDA", "role": "I2C_SDA"},
+    {"name": "ADDR", "role": "GPIO", "optional": true},
+    {"name": "ALRT", "role": "GPIO", "optional": true},
+    {"name": "A0", "role": "GPIO"},
+    {"name": "A1", "role": "GPIO"},
+    {"name": "A2", "role": "GPIO"},
+    {"name": "A3", "role": "GPIO"}
+  ],
+
+  "i2c_address": "0x48",
+  "datasheet_url": "https://www.ti.com/lit/ds/symlink/ads1115.pdf",
+  "notes": "16-bit ADC with 4 single-ended or 2 differential inputs. Programmable gain amplifier (PGA) from ±256mV to ±6.144V. I2C address: 0x48-0x4B via ADDR pin. Sample rates: 8 to 860 SPS. ALRT pin for comparator/conversion ready interrupt."
+}

--- a/src/pinviz/device_configs/sensors/ds3231.json
+++ b/src/pinviz/device_configs/sensors/ds3231.json
@@ -1,0 +1,19 @@
+{
+  "id": "ds3231",
+  "name": "DS3231 RTC",
+  "category": "sensors",
+  "description": "Extremely accurate I2C real-time clock with temperature-compensated crystal oscillator",
+
+  "pins": [
+    {"name": "VCC", "role": "3V3"},
+    {"name": "GND", "role": "GND"},
+    {"name": "SCL", "role": "I2C_SCL"},
+    {"name": "SDA", "role": "I2C_SDA"},
+    {"name": "SQW", "role": "GPIO", "optional": true},
+    {"name": "32K", "role": "GPIO", "optional": true}
+  ],
+
+  "i2c_address": "0x68",
+  "datasheet_url": "https://www.analog.com/media/en/technical-documentation/data-sheets/DS3231.pdf",
+  "notes": "Battery-backed RTC with ±2ppm accuracy. Tracks seconds, minutes, hours, day, date, month, and year with leap-year compensation. SQW pin outputs programmable square wave or alarm interrupt. Includes internal temperature sensor."
+}

--- a/src/pinviz/device_configs/sensors/ina219.json
+++ b/src/pinviz/device_configs/sensors/ina219.json
@@ -1,0 +1,17 @@
+{
+  "id": "ina219",
+  "name": "INA219 Current Sensor",
+  "category": "sensors",
+  "description": "High-side current/voltage/power monitor with I2C interface",
+
+  "pins": [
+    {"name": "VCC", "role": "3V3"},
+    {"name": "GND", "role": "GND"},
+    {"name": "SCL", "role": "I2C_SCL"},
+    {"name": "SDA", "role": "I2C_SDA"}
+  ],
+
+  "i2c_address": "0x40",
+  "datasheet_url": "https://www.ti.com/product/INA219",
+  "notes": "Measures voltage (0-26V), current (up to ±3.2A), and power. I2C address configurable via A0/A1 jumpers (0x40-0x4F). Useful for battery monitoring and power profiling."
+}

--- a/src/pinviz/device_configs/sensors/max30102.json
+++ b/src/pinviz/device_configs/sensors/max30102.json
@@ -1,0 +1,18 @@
+{
+  "id": "max30102",
+  "name": "MAX30102 Pulse Oximeter",
+  "category": "sensors",
+  "description": "Heart rate and SpO2 sensor with integrated red and IR LEDs for pulse oximetry",
+
+  "pins": [
+    {"name": "VIN", "role": "3V3"},
+    {"name": "GND", "role": "GND"},
+    {"name": "SCL", "role": "I2C_SCL"},
+    {"name": "SDA", "role": "I2C_SDA"},
+    {"name": "INT", "role": "GPIO", "optional": true}
+  ],
+
+  "i2c_address": "0x57",
+  "datasheet_url": "https://datasheets.maximintegrated.com/en/ds/MAX30102.pdf",
+  "notes": "Integrated pulse oximetry and heart rate monitor. Built-in red (660nm) and IR (880nm) LEDs with photodetector. Sample rates up to 3200 samples/second. INT pin provides interrupt for FIFO full/ready events. Low power: 600µA in SpO2 mode."
+}

--- a/src/pinviz/device_configs/sensors/mcp3008.json
+++ b/src/pinviz/device_configs/sensors/mcp3008.json
@@ -1,0 +1,28 @@
+{
+  "id": "mcp3008",
+  "name": "MCP3008 ADC",
+  "category": "sensors",
+  "description": "8-channel 10-bit analog-to-digital converter with SPI interface",
+
+  "pins": [
+    {"name": "VDD", "role": "3V3"},
+    {"name": "VREF", "role": "3V3"},
+    {"name": "AGND", "role": "GND"},
+    {"name": "CLK", "role": "SPI_SCLK"},
+    {"name": "DOUT", "role": "SPI_MISO"},
+    {"name": "DIN", "role": "SPI_MOSI"},
+    {"name": "CS", "role": "SPI_CE0"},
+    {"name": "DGND", "role": "GND"},
+    {"name": "CH0", "role": "GPIO"},
+    {"name": "CH1", "role": "GPIO"},
+    {"name": "CH2", "role": "GPIO"},
+    {"name": "CH3", "role": "GPIO"},
+    {"name": "CH4", "role": "GPIO"},
+    {"name": "CH5", "role": "GPIO"},
+    {"name": "CH6", "role": "GPIO"},
+    {"name": "CH7", "role": "GPIO"}
+  ],
+
+  "datasheet_url": "https://ww1.microchip.com/downloads/en/DeviceDoc/21295d.pdf",
+  "notes": "8 single-ended analog input channels (CH0-CH7), or 4 differential pairs. 10-bit resolution (0-1023). Sample rate up to 200 ksps. VREF sets the full-scale voltage range."
+}

--- a/src/pinviz/device_configs/sensors/mpu6050.json
+++ b/src/pinviz/device_configs/sensors/mpu6050.json
@@ -1,0 +1,19 @@
+{
+  "id": "mpu6050",
+  "name": "MPU6050 IMU",
+  "category": "sensors",
+  "description": "6-axis gyroscope and accelerometer I2C sensor",
+
+  "pins": [
+    {"name": "VCC", "role": "3V3"},
+    {"name": "GND", "role": "GND"},
+    {"name": "SCL", "role": "I2C_SCL"},
+    {"name": "SDA", "role": "I2C_SDA"},
+    {"name": "AD0", "role": "GPIO", "optional": true},
+    {"name": "INT", "role": "GPIO", "optional": true}
+  ],
+
+  "i2c_address": "0x68",
+  "datasheet_url": "https://invensense.tdk.com/wp-content/uploads/2015/02/MPU-6000-Datasheet1.pdf",
+  "notes": "I2C address is 0x68 (AD0 low) or 0x69 (AD0 high). Measures 3-axis gyroscope and 3-axis accelerometer. INT pin provides motion detection interrupts."
+}

--- a/src/pinviz/device_configs/sensors/mpu9250.json
+++ b/src/pinviz/device_configs/sensors/mpu9250.json
@@ -1,0 +1,19 @@
+{
+  "id": "mpu9250",
+  "name": "MPU9250 9-Axis IMU",
+  "category": "sensors",
+  "description": "9-axis motion tracking device with 3-axis gyroscope, 3-axis accelerometer, and 3-axis magnetometer",
+
+  "pins": [
+    {"name": "VCC", "role": "3V3"},
+    {"name": "GND", "role": "GND"},
+    {"name": "SCL", "role": "I2C_SCL"},
+    {"name": "SDA", "role": "I2C_SDA"},
+    {"name": "AD0", "role": "GPIO", "optional": true},
+    {"name": "INT", "role": "GPIO", "optional": true}
+  ],
+
+  "i2c_address": "0x68",
+  "datasheet_url": "https://invensense.tdk.com/wp-content/uploads/2015/02/PS-MPU-9250A-01-v1.1.pdf",
+  "notes": "9-axis sensor: 3-axis gyro, 3-axis accelerometer, 3-axis magnetometer (AK8963). I2C address: 0x68 (AD0 low) or 0x69 (AD0 high). Built-in Digital Motion Processor (DMP). INT pin for motion detection and data ready interrupts."
+}

--- a/src/pinviz/device_configs/sensors/tsl2561.json
+++ b/src/pinviz/device_configs/sensors/tsl2561.json
@@ -1,0 +1,18 @@
+{
+  "id": "tsl2561",
+  "name": "TSL2561 Light Sensor",
+  "category": "sensors",
+  "description": "Digital light sensor with I2C interface, measures visible and infrared light",
+
+  "pins": [
+    {"name": "VCC", "role": "3V3"},
+    {"name": "GND", "role": "GND"},
+    {"name": "SCL", "role": "I2C_SCL"},
+    {"name": "SDA", "role": "I2C_SDA"},
+    {"name": "INT", "role": "GPIO", "optional": true}
+  ],
+
+  "i2c_address": "0x39",
+  "datasheet_url": "https://ams.com/documents/20143/36005/TSL2561_DS000110_3-00.pdf",
+  "notes": "I2C address can be 0x29, 0x39, or 0x49 depending on ADDR pin. Dual photodiodes measure visible + IR and IR only. Dynamic range of 0.1 to 40,000 lux. Programmable interrupt thresholds."
+}

--- a/src/pinviz/device_configs/sensors/vl53l0x.json
+++ b/src/pinviz/device_configs/sensors/vl53l0x.json
@@ -1,0 +1,19 @@
+{
+  "id": "vl53l0x",
+  "name": "VL53L0X ToF Sensor",
+  "category": "sensors",
+  "description": "Time-of-Flight ranging sensor with I2C interface, measures distances up to 2 meters",
+
+  "pins": [
+    {"name": "VIN", "role": "3V3"},
+    {"name": "GND", "role": "GND"},
+    {"name": "SCL", "role": "I2C_SCL"},
+    {"name": "SDA", "role": "I2C_SDA"},
+    {"name": "XSHUT", "role": "GPIO", "optional": true},
+    {"name": "GPIO1", "role": "GPIO", "optional": true}
+  ],
+
+  "i2c_address": "0x29",
+  "datasheet_url": "https://www.st.com/resource/en/datasheet/vl53l0x.pdf",
+  "notes": "Time-of-Flight (ToF) laser ranging sensor. Accurate distance measurements from 30mm to 2000mm. Independent of target reflectance. XSHUT pin for hardware standby. GPIO1 pin for interrupt output (measurement ready, threshold events)."
+}

--- a/src/pinviz/schemas.py
+++ b/src/pinviz/schemas.py
@@ -52,6 +52,7 @@ VALID_BOARD_NAMES = {
 
 # Valid device types from the device registry
 VALID_DEVICE_TYPES = {
+    "ads1115",
     "all_left",
     "all_right",
     "bh1750",
@@ -59,20 +60,40 @@ VALID_DEVICE_TYPES = {
     "button",
     "dht22",
     "ds18b20",
+    "ds3231",
+    "esp8266",
+    "hc05",
     "hcsr04",
     "i2c_device",
     "i2c",  # Alias for i2c_device
+    "ina219",
     "ir_led_ring",
+    "l298n",
+    "lcd1602",
     "led",
+    "max30102",
+    "mcp2515",
     "mcp3008",
     "mixed_sides",
+    "mpu6050",
+    "mpu9250",
+    "nrf24l01",
     "pir",
+    "rc522",
     "relay_auto",
     "relay_module",
+    "sg90",
+    "sim800l",
     "single_pin_each_side",
     "spi_device",
     "spi",  # Alias for spi_device
     "ssd1306",
+    "st7735",
+    "sx1278",
+    "tb6612fng",
+    "tsl2561",
+    "uln2003",
+    "vl53l0x",
 }
 
 # Valid pin roles

--- a/uv.lock
+++ b/uv.lock
@@ -974,7 +974,7 @@ wheels = [
 
 [[package]]
 name = "pinviz"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
Expanded the device library from ~30 to **40+ unique device templates**, adding a new **communication** category with 7 wireless/connectivity modules, plus additional sensors, actuators, and displays.

## New Devices by Category

### 📡 Communication Modules (7 devices)
- **nRF24L01+** - 2.4GHz wireless transceiver (SPI)
- **HC-05** - Bluetooth 2.0 module (UART)
- **ESP8266** - WiFi module (UART AT commands)
- **SX1278** - LoRa long-range transceiver (SPI)
- **SIM800L** - GSM/GPRS cellular module (UART)
- **RC522** - 13.56MHz RFID/NFC reader (SPI)
- **MCP2515** - CAN bus controller with TJA1050 transceiver (SPI)

### 🔬 Sensors (8 devices)
- **INA219** - Current/voltage/power monitor (I2C)
- **ADS1115** - 16-bit precision ADC with PGA (I2C)
- **DS3231** - High-precision real-time clock (I2C)
- **MPU6050** - 6-axis gyroscope/accelerometer (I2C)
- **MPU9250** - 9-axis IMU with magnetometer (I2C)
- **MAX30102** - Heart rate and SpO2 sensor (I2C)
- **TSL2561** - Digital light sensor (I2C)
- **VL53L0X** - Time-of-Flight distance sensor (I2C)

### ⚙️ Actuators (4 devices)
- **L298N** - Dual H-bridge motor driver (up to 2A per channel)
- **TB6612FNG** - Dual motor driver with PWM (1.2A per channel)
- **ULN2003** - Darlington array for stepper motors (500mA per channel)
- **SG90** - Micro servo motor (PWM control)

### 🖥️ Displays (2 devices)
- **LCD1602** - 16x2 character LCD with I2C backpack
- **ST7735** - 1.8" TFT color display 128x160 (SPI)

## Example Configurations

Added **17 new example YAML files** demonstrating proper wiring for each device:
- `examples/nrf24l01_wireless.yaml`
- `examples/hc05_bluetooth.yaml`
- `examples/esp8266_wifi.yaml`
- `examples/sx1278_lora.yaml`
- `examples/sim800l_gsm.yaml`
- `examples/rc522_rfid.yaml`
- `examples/ina219_power_monitor.yaml`
- `examples/ads1115_precision_adc.yaml`
- `examples/ds3231_rtc.yaml`
- `examples/mpu6050_imu.yaml`
- `examples/mcp3008_adc.yaml`
- `examples/l298n_dual_motor.yaml`
- `examples/tb6612fng_motor.yaml`
- `examples/uln2003_stepper.yaml`
- `examples/sg90_servo.yaml`
- `examples/lcd1602_display.yaml`
- `examples/st7735_tft.yaml`

All examples validated successfully with proper pin role compatibility.

## Technical Changes

### Device Configuration
- Created `src/pinviz/device_configs/communication/` directory with 7 JSON configs
- Added 8 new sensor configs, 4 actuator configs, 2 display configs
- All devices include:
  - Datasheet URLs for reference
  - I2C addresses where applicable
  - Optional pin definitions
  - Detailed notes on power requirements and usage

### Schema Updates
- Updated `VALID_DEVICE_TYPES` in `schemas.py` with all new device IDs
- Maintains alphabetical ordering for easier maintenance

### Bug Fixes
- **Fixed UART pin roles** for HC-05, ESP8266, and SIM800L:
  - Device TXD pins now correctly marked as `UART_TX` (output)
  - Device RXD pins now correctly marked as `UART_RX` (input)
  - Ensures proper validation of UART crossover connections (Pi TX → Device RX)

## Device Library Statistics

- **Total devices**: 40 unique templates
- **Categories**: 6 (sensors, actuators, LEDs, displays, I/O, communication)
- **Interfaces supported**: I2C, SPI, UART, GPIO, PWM
- **Example diagrams**: 30+ YAML configurations

## Test Plan

- [x] All device JSON configs validated with device registry
- [x] All 17 new examples render successfully to SVG
- [x] Schema validation passes for all device types
- [x] UART pin role validation works correctly
- [x] Device registry loads all 40 devices
- [x] CLI `pinviz list` shows all devices
- [x] No regressions in existing device functionality

## Screenshots

Rendered example diagrams available in `out/` directory:
- `out/communication/` - 6 wireless/comm module diagrams
- `out/sensors/` - 5 sensor module diagrams
- `out/actuators/` - 4 motor/actuator diagrams
- `out/displays/` - 2 display diagrams

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)