### PR TITLE
refactor: extract board pin knowledge to Board.pins_by_role()

### DIFF
--- a/src/pinviz/config_loader.py
+++ b/src/pinviz/config_loader.py
@@ -61,12 +61,7 @@ class PinAssigner:
         # Track which pins have been assigned: role -> list of assigned pin numbers
         self._role_assignment_index: dict[PinRole, int] = {}
         # Build lookup: role -> list of available pin numbers
-        self._pins_by_role: dict[PinRole, list[int]] = {}
-
-        for pin in board.pins:
-            if pin.role not in self._pins_by_role:
-                self._pins_by_role[pin.role] = []
-            self._pins_by_role[pin.role].append(pin.number)
+        self._pins_by_role = board.pins_by_role()
 
         log.debug(
             "pin_assigner_initialized",

--- a/src/pinviz/mcp/connection_builder.py
+++ b/src/pinviz/mcp/connection_builder.py
@@ -3,7 +3,7 @@
 from pinviz.board_selection import AliasBoardSelectionStrategy, BoardSelectionStrategy
 from pinviz.diagram_builder import DiagramBuilder
 from pinviz.mcp.pin_assignment import PinAssignment
-from pinviz.model import DEFAULT_COLORS, Connection, Device, Diagram
+from pinviz.model import DEFAULT_COLORS, Board, Connection, Device, Diagram
 
 from .adapters import McpDeviceAdapter
 
@@ -35,6 +35,7 @@ class ConnectionBuilder:
         devices_data: list[dict],
         board_name: str = "raspberry_pi_5",
         title: str = "GPIO Wiring Diagram",
+        board: Board | None = None,
     ) -> Diagram:
         """
         Build a complete Diagram from pin assignments.
@@ -44,6 +45,7 @@ class ConnectionBuilder:
             devices_data: List of device dictionaries from database
             board_name: Board type (default: "raspberry_pi_5")
             title: Diagram title
+            board: Pre-loaded Board object (avoids redundant lookup)
 
         Returns:
             Complete Diagram object ready for rendering
@@ -56,14 +58,17 @@ class ConnectionBuilder:
 
         # Create diagram through the shared builder so MCP assembly matches
         # config-based assembly semantics.
-        return (
+        builder = (
             DiagramBuilder(self._board_selection_strategy)
             .with_title(title)
-            .with_board_name(board_name)
             .with_devices(devices)
             .with_connections(connections)
-            .build()
         )
+        if board is not None:
+            builder.with_board(board)
+        else:
+            builder.with_board_name(board_name)
+        return builder.build()
 
     def _get_board(self, board_name: str):
         """Get board object by name."""

--- a/src/pinviz/mcp/pin_assignment.py
+++ b/src/pinviz/mcp/pin_assignment.py
@@ -12,7 +12,7 @@ This module implements algorithms for automatic pin assignment, handling:
 from dataclasses import dataclass, field
 from typing import Protocol
 
-from pinviz.model import Component, PinRole
+from pinviz.model import Board, Component, PinRole
 
 
 @dataclass
@@ -50,37 +50,8 @@ class PinAllocationState:
     power_5v_count: int = 0
     ground_count: int = 0
 
-    # Available GPIO pins (BCM numbers)
-    available_gpio: list[int] = field(
-        default_factory=lambda: [
-            2,
-            3,
-            4,
-            17,
-            27,
-            22,
-            10,
-            9,
-            11,
-            5,
-            6,
-            13,
-            19,
-            26,
-            14,
-            15,
-            18,
-            23,
-            24,
-            25,
-            8,
-            7,
-            12,
-            16,
-            20,
-            21,
-        ]
-    )
+    # Available GPIO pins (physical pin numbers)
+    available_gpio: list[int] = field(default_factory=list)
 
 
 class PinAssignmentStrategy(Protocol):
@@ -138,63 +109,29 @@ class PinAssigner:
     handling shared buses (I2C, SPI) and preventing conflicts.
     """
 
-    # Pin mappings for Raspberry Pi 5 (physical pin number -> BCM GPIO)
-    GPIO_BCM_TO_PHYSICAL = {
-        2: 3,
-        3: 5,
-        4: 7,
-        17: 11,
-        27: 13,
-        22: 15,
-        10: 19,
-        9: 21,
-        11: 23,
-        5: 29,
-        6: 31,
-        13: 33,
-        19: 35,
-        26: 37,
-        14: 8,
-        15: 10,
-        18: 12,
-        23: 16,
-        24: 18,
-        25: 22,
-        8: 24,
-        7: 26,
-        12: 32,
-        16: 36,
-        20: 38,
-        21: 40,
-    }
+    # Roles that have a single fixed pin on most boards
+    FIXED_ROLES = frozenset(
+        {
+            PinRole.UART_TX,
+            PinRole.UART_RX,
+            PinRole.PCM_CLK,
+            PinRole.PCM_FS,
+            PinRole.PCM_DIN,
+            PinRole.PCM_DOUT,
+            PinRole.I2C_EEPROM,
+        }
+    )
 
-    # Fixed special pins
-    I2C_SDA_PIN = 3  # Physical pin 3 (GPIO2/SDA1)
-    I2C_SCL_PIN = 5  # Physical pin 5 (GPIO3/SCL1)
-    SPI_MOSI_PIN = 19  # Physical pin 19 (GPIO10)
-    SPI_MISO_PIN = 21  # Physical pin 21 (GPIO9)
-    SPI_SCLK_PIN = 23  # Physical pin 23 (GPIO11)
-    SPI_CE0_PIN = 24  # Physical pin 24 (GPIO8)
-    SPI_CE1_PIN = 26  # Physical pin 26 (GPIO7)
+    def __init__(self, board: Board):
+        """Initialize the pin assigner with a board.
 
-    # Power pins (multiple available)
-    POWER_3V3_PINS = [1, 17]  # Physical pins 1, 17
-    POWER_5V_PINS = [2, 4]  # Physical pins 2, 4
-    GROUND_PINS = [6, 9, 14, 20, 25, 30, 34, 39]  # Physical GND pins
-    PWM_PINS = [32, 33, 12, 35]  # Physical PWM-capable pins
-    FIXED_ROLE_PINS = {
-        PinRole.UART_TX: 8,
-        PinRole.UART_RX: 10,
-        PinRole.PCM_CLK: 12,
-        PinRole.PCM_FS: 35,
-        PinRole.PCM_DIN: 38,
-        PinRole.PCM_DOUT: 40,
-        PinRole.I2C_EEPROM: 27,
-    }
-
-    def __init__(self):
-        """Initialize the pin assigner."""
-        self.state = PinAllocationState()
+        Args:
+            board: Board object whose pins define available assignments.
+        """
+        self._pin_map = board.pins_by_role()
+        self.state = PinAllocationState(
+            available_gpio=list(self._pin_map.get(PinRole.GPIO, [])),
+        )
         self.assignments: list[PinAssignment] = []
         self._strategies: dict[str, PinAssignmentStrategy] = {
             "I2C": I2CPinAssignmentStrategy(),
@@ -214,7 +151,9 @@ class PinAssigner:
             - assignments: List of PinAssignment objects
             - warnings: List of warning messages
         """
-        self.state = PinAllocationState()
+        self.state = PinAllocationState(
+            available_gpio=list(self._pin_map.get(PinRole.GPIO, [])),
+        )
         self.assignments = []
         warnings = []
 
@@ -286,7 +225,7 @@ class PinAssigner:
             else:
                 self._append_assignment(board_pin, device_name, pin_name, pin_role)
         elif pin_role == PinRole.PWM:
-            board_pin = self._assign_from_candidates(self.PWM_PINS)
+            board_pin = self._assign_from_candidates(self._pin_map.get(PinRole.PWM, []))
             if board_pin is None:
                 warnings.append(f"Warning: No PWM pins available for {device_name}/{pin_name}")
             else:
@@ -307,7 +246,7 @@ class PinAssigner:
             )
         elif pin_role == PinRole.GROUND:
             self._append_assignment(self._assign_ground_pin(), device_name, pin_name, pin_role)
-        elif pin_role in self.FIXED_ROLE_PINS:
+        elif pin_role in self.FIXED_ROLES:
             board_pin = self._assign_fixed_role_pin(pin_role)
             if board_pin is None:
                 warnings.append(
@@ -324,8 +263,7 @@ class PinAssigner:
 
     def _assign_gpio_pin(self) -> int | None:
         while self.state.available_gpio:
-            gpio_bcm = self.state.available_gpio.pop(0)
-            board_pin = self.GPIO_BCM_TO_PHYSICAL[gpio_bcm]
+            board_pin = self.state.available_gpio.pop(0)
             if board_pin in self.state.used_pins:
                 continue
 
@@ -342,7 +280,10 @@ class PinAssigner:
         return None
 
     def _assign_fixed_role_pin(self, pin_role: PinRole) -> int | None:
-        board_pin = self.FIXED_ROLE_PINS[pin_role]
+        pins = self._pin_map.get(pin_role, [])
+        if not pins:
+            return None
+        board_pin = pins[0]
         if board_pin in self.state.used_pins:
             return None
 
@@ -356,10 +297,15 @@ class PinAssigner:
 
         # Assign I2C bus pins (shared across all I2C devices)
         if self.state.i2c_sda_pin is None:
-            self.state.i2c_sda_pin = self.I2C_SDA_PIN
-            self.state.i2c_scl_pin = self.I2C_SCL_PIN
-            self.state.used_pins.add(self.I2C_SDA_PIN)
-            self.state.used_pins.add(self.I2C_SCL_PIN)
+            sda_pins = self._pin_map.get(PinRole.I2C_SDA, [])
+            scl_pins = self._pin_map.get(PinRole.I2C_SCL, [])
+            if not sda_pins or not scl_pins:
+                warnings.append(f"Error: Board has no I2C pins for {device_name}")
+                return warnings
+            self.state.i2c_sda_pin = sda_pins[0]
+            self.state.i2c_scl_pin = scl_pins[0]
+            self.state.used_pins.add(self.state.i2c_sda_pin)
+            self.state.used_pins.add(self.state.i2c_scl_pin)
 
         self.state.i2c_devices.append(device_name)
 
@@ -369,9 +315,9 @@ class PinAssigner:
             pin_role = PinRole(pin["role"])
 
             if pin_role == PinRole.I2C_SDA:
-                self._append_assignment(self.I2C_SDA_PIN, device_name, pin_name, pin_role)
+                self._append_assignment(self.state.i2c_sda_pin, device_name, pin_name, pin_role)
             elif pin_role == PinRole.I2C_SCL:
-                self._append_assignment(self.I2C_SCL_PIN, device_name, pin_name, pin_role)
+                self._append_assignment(self.state.i2c_scl_pin, device_name, pin_name, pin_role)
             else:
                 warnings.extend(self._assign_general_pin(device_name, pin_name, pin_role))
 
@@ -393,21 +339,30 @@ class PinAssigner:
 
         # Assign SPI bus pins (shared)
         if self.state.spi_mosi_pin is None:
-            self.state.spi_mosi_pin = self.SPI_MOSI_PIN
-            self.state.spi_miso_pin = self.SPI_MISO_PIN
-            self.state.spi_sclk_pin = self.SPI_SCLK_PIN
-            self.state.used_pins.add(self.SPI_MOSI_PIN)
-            self.state.used_pins.add(self.SPI_MISO_PIN)
-            self.state.used_pins.add(self.SPI_SCLK_PIN)
+            mosi_pins = self._pin_map.get(PinRole.SPI_MOSI, [])
+            miso_pins = self._pin_map.get(PinRole.SPI_MISO, [])
+            sclk_pins = self._pin_map.get(PinRole.SPI_SCLK, [])
+            if not mosi_pins or not sclk_pins:
+                warnings.append(f"Error: Board has no SPI pins for {device_name}")
+                return warnings
+            self.state.spi_mosi_pin = mosi_pins[0]
+            self.state.spi_miso_pin = miso_pins[0] if miso_pins else None
+            self.state.spi_sclk_pin = sclk_pins[0]
+            self.state.used_pins.add(self.state.spi_mosi_pin)
+            if self.state.spi_miso_pin is not None:
+                self.state.used_pins.add(self.state.spi_miso_pin)
+            self.state.used_pins.add(self.state.spi_sclk_pin)
 
         # Assign chip select (CE0 or CE1)
+        ce0_pins = self._pin_map.get(PinRole.SPI_CE0, [])
+        ce1_pins = self._pin_map.get(PinRole.SPI_CE1, [])
         ce_pin = None
-        if not self.state.spi_ce0_assigned:
-            ce_pin = self.SPI_CE0_PIN
+        if not self.state.spi_ce0_assigned and ce0_pins:
+            ce_pin = ce0_pins[0]
             self.state.spi_ce0_assigned = True
             self.state.used_pins.add(ce_pin)
-        elif not self.state.spi_ce1_assigned:
-            ce_pin = self.SPI_CE1_PIN
+        elif not self.state.spi_ce1_assigned and ce1_pins:
+            ce_pin = ce1_pins[0]
             self.state.spi_ce1_assigned = True
             self.state.used_pins.add(ce_pin)
         else:
@@ -420,11 +375,11 @@ class PinAssigner:
             pin_role = PinRole(pin["role"])
 
             if pin_role == PinRole.SPI_MOSI:
-                self._append_assignment(self.SPI_MOSI_PIN, device_name, pin_name, pin_role)
+                self._append_assignment(self.state.spi_mosi_pin, device_name, pin_name, pin_role)
             elif pin_role == PinRole.SPI_MISO:
-                self._append_assignment(self.SPI_MISO_PIN, device_name, pin_name, pin_role)
+                self._append_assignment(self.state.spi_miso_pin, device_name, pin_name, pin_role)
             elif pin_role == PinRole.SPI_SCLK:
-                self._append_assignment(self.SPI_SCLK_PIN, device_name, pin_name, pin_role)
+                self._append_assignment(self.state.spi_sclk_pin, device_name, pin_name, pin_role)
             elif pin_role in (PinRole.SPI_CE0, PinRole.SPI_CE1):
                 # Use the assigned CE pin
                 self._append_assignment(ce_pin, device_name, pin_name, pin_role)
@@ -447,19 +402,22 @@ class PinAssigner:
 
     def _assign_power_pin(self, role: PinRole) -> int:
         """Assign a power pin (3.3V or 5V)."""
+        pins = self._pin_map.get(role, [])
+        if not pins:
+            raise ValueError(f"Board has no pins for role: {role}")
         if role == PinRole.POWER_3V3:
             self.state.power_3v3_count += 1
-            # Alternate between available 3.3V pins
-            return self.POWER_3V3_PINS[(self.state.power_3v3_count - 1) % len(self.POWER_3V3_PINS)]
+            return pins[(self.state.power_3v3_count - 1) % len(pins)]
         elif role == PinRole.POWER_5V:
             self.state.power_5v_count += 1
-            # Alternate between available 5V pins
-            return self.POWER_5V_PINS[(self.state.power_5v_count - 1) % len(self.POWER_5V_PINS)]
+            return pins[(self.state.power_5v_count - 1) % len(pins)]
         else:
             raise ValueError(f"Invalid power role: {role}")
 
     def _assign_ground_pin(self) -> int:
         """Assign a ground pin."""
+        pins = self._pin_map.get(PinRole.GROUND, [])
+        if not pins:
+            raise ValueError("Board has no ground pins")
         self.state.ground_count += 1
-        # Alternate between available ground pins
-        return self.GROUND_PINS[(self.state.ground_count - 1) % len(self.GROUND_PINS)]
+        return pins[(self.state.ground_count - 1) % len(pins)]

--- a/src/pinviz/mcp/server.py
+++ b/src/pinviz/mcp/server.py
@@ -157,6 +157,8 @@ def generate_diagram(prompt: str, output_format: str = "yaml", title: str | None
         - DO NOT modify or reconstruct the YAML - use the 'yaml_content' field exactly as provided
         - The YAML includes full device pin definitions required by the pinviz CLI
     """
+    from pinviz.board_selection import AliasBoardSelectionStrategy
+
     from .parser import PromptParser
     from .pin_assignment import PinAssigner
 
@@ -175,6 +177,10 @@ def generate_diagram(prompt: str, output_format: str = "yaml", title: str | None
                 },
                 indent=2,
             )
+
+        # Step 1.5: Resolve board early so PinAssigner can use it
+        board_strategy = AliasBoardSelectionStrategy(fallback_board_name="raspberry_pi_5")
+        board = board_strategy.select_board(parsed.board)
 
         # Step 2: Look up devices in database
         devices_data = []
@@ -200,15 +206,15 @@ def generate_diagram(prompt: str, output_format: str = "yaml", title: str | None
             )
 
         # Step 3: Assign pins intelligently
-        pin_assigner = PinAssigner()
+        pin_assigner = PinAssigner(board)
         assignments, warnings = pin_assigner.assign_pins(devices_data)
 
         # Step 3.5: Build complete diagram and validate
-        builder = ConnectionBuilder()
+        builder = ConnectionBuilder(board_selection_strategy=board_strategy)
         diagram = builder.build_diagram(
             assignments=assignments,
             devices_data=devices_data,
-            board_name=parsed.board,
+            board=board,
             title=title
             or (
                 f"{', '.join([d['name'] for d in devices_data])} Wiring"

--- a/src/pinviz/model.py
+++ b/src/pinviz/model.py
@@ -236,6 +236,17 @@ class Board:
         """
         return next((p for p in self.pins if p.number == pin_number), None)
 
+    def pins_by_role(self) -> dict[PinRole, list[int]]:
+        """Group physical pin numbers by their role.
+
+        Returns:
+            Mapping from PinRole to list of physical pin numbers with that role.
+        """
+        result: dict[PinRole, list[int]] = {}
+        for pin in self.pins:
+            result.setdefault(pin.role, []).append(pin.number)
+        return result
+
     def get_pin_by_bcm(self, bcm_number: int) -> HeaderPin | None:
         """
         Get a pin by its BCM GPIO number.

--- a/tests/test_integration_phase2.py
+++ b/tests/test_integration_phase2.py
@@ -1,5 +1,6 @@
 """Integration tests for Phase 2: Full pipeline from prompt to diagram."""
 
+from pinviz import boards
 from pinviz.mcp.connection_builder import ConnectionBuilder
 from pinviz.mcp.device_manager import DeviceManager
 from pinviz.mcp.parser import PromptParser
@@ -15,7 +16,7 @@ class TestPhase2Integration:
         """Set up test fixtures."""
         self.device_manager = DeviceManager()
         self.parser = PromptParser()
-        self.pin_assigner = PinAssigner()
+        self.pin_assigner = PinAssigner(boards.raspberry_pi_5())
         self.connection_builder = ConnectionBuilder()
 
     def test_single_i2c_device_flow(self):
@@ -197,7 +198,7 @@ class TestPhase2Integration:
                     devices_data.append(device.to_dict())
 
             # Assign pins
-            pin_assigner = PinAssigner()
+            pin_assigner = PinAssigner(boards.raspberry_pi_5())
             assignments, warnings = pin_assigner.assign_pins(devices_data)
 
             # Build diagram
@@ -266,7 +267,7 @@ class TestPhase2PerformanceBaseline:
             if device:
                 devices_data.append(device.to_dict())
 
-        pin_assigner = PinAssigner()
+        pin_assigner = PinAssigner(boards.raspberry_pi_5())
         assignments, warnings = pin_assigner.assign_pins(devices_data)
 
         connection_builder = ConnectionBuilder()

--- a/tests/test_integration_real_world.py
+++ b/tests/test_integration_real_world.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pytest
 
+from pinviz import boards
 from pinviz.mcp.connection_builder import ConnectionBuilder
 from pinviz.mcp.device_manager import DeviceManager
 from pinviz.mcp.parser import PromptParser
@@ -38,7 +39,7 @@ def parser():
 @pytest.fixture
 def pin_assigner():
     """Shared pin assigner."""
-    return PinAssigner()
+    return PinAssigner(boards.raspberry_pi_5())
 
 
 @pytest.fixture

--- a/tests/test_mcp_local.py
+++ b/tests/test_mcp_local.py
@@ -9,6 +9,7 @@ import tempfile
 from pathlib import Path
 
 try:
+    from pinviz import boards
     from pinviz.mcp.connection_builder import ConnectionBuilder
     from pinviz.mcp.device_manager import DeviceManager
     from pinviz.mcp.parser import PromptParser
@@ -18,6 +19,7 @@ except ModuleNotFoundError:
     # Allow running this file directly without editable install.
     PROJECT_ROOT = Path(__file__).resolve().parents[1]
     sys.path.insert(0, str(PROJECT_ROOT / "src"))
+    from pinviz import boards
     from pinviz.mcp.connection_builder import ConnectionBuilder
     from pinviz.mcp.device_manager import DeviceManager
     from pinviz.mcp.parser import PromptParser
@@ -60,7 +62,7 @@ def test_prompt_parser():
 def test_pin_assignment():
     """I2C devices should share SDA/SCL bus pins."""
     dm = DeviceManager()
-    assigner = PinAssigner()
+    assigner = PinAssigner(boards.raspberry_pi_5())
 
     bme280 = dm.get_device_by_name("BME280")
     bh1750 = dm.get_device_by_name("BH1750")
@@ -89,7 +91,7 @@ def test_diagram_generation(tmp_path):
 
     dm = DeviceManager()
     parser = PromptParser()
-    assigner = PinAssigner()
+    assigner = PinAssigner(boards.raspberry_pi_5())
     builder = ConnectionBuilder()
     renderer = SVGRenderer()
 

--- a/tests/test_pin_assignment.py
+++ b/tests/test_pin_assignment.py
@@ -1,7 +1,20 @@
 """Unit tests for the pin assignment module."""
 
+import pytest
+
+from pinviz import boards
 from pinviz.mcp.pin_assignment import PinAllocationState, PinAssigner, PinAssignment
 from pinviz.model import PinRole
+
+
+@pytest.fixture()
+def pi5_board():
+    return boards.raspberry_pi_5()
+
+
+@pytest.fixture()
+def pico_board():
+    return boards.load_board_from_config("raspberry_pi_pico")
 
 
 class TestPinAllocationState:
@@ -18,22 +31,22 @@ class TestPinAllocationState:
         assert state.spi_mosi_pin is None
         assert state.spi_ce0_assigned is False
         assert state.power_3v3_count == 0
-        assert len(state.available_gpio) > 0
+        assert len(state.available_gpio) == 0
 
 
 class TestPinAssigner:
     """Test suite for PinAssigner class."""
 
-    def test_initialization(self):
+    def test_initialization(self, pi5_board):
         """Test that assigner initializes correctly."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
 
         assert isinstance(assigner.state, PinAllocationState)
         assert len(assigner.assignments) == 0
 
-    def test_single_i2c_device(self):
+    def test_single_i2c_device(self, pi5_board):
         """Test assigning pins for a single I2C device."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
 
         device = {
             "name": "BME280 Sensor",
@@ -58,9 +71,9 @@ class TestPinAssigner:
         assert sda_assignment.board_pin_number == 3
         assert scl_assignment.board_pin_number == 5
 
-    def test_multiple_i2c_devices_share_bus(self):
+    def test_multiple_i2c_devices_share_bus(self, pi5_board):
         """Test that multiple I2C devices share the same I2C bus."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
 
         devices = [
             {
@@ -102,9 +115,9 @@ class TestPinAssigner:
         assert len(warnings) > 0
         assert any("I2C address" in w for w in warnings)
 
-    def test_i2c_device_with_gpio_interrupt_pin(self):
+    def test_i2c_device_with_gpio_interrupt_pin(self, pi5_board):
         """I2C strategies should still allocate non-bus pins like INT."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
 
         device = {
             "name": "MPU6050",
@@ -123,11 +136,11 @@ class TestPinAssigner:
         assert len(assignments) == 5
         assert len(warnings) == 0
         int_assignment = next(a for a in assignments if a.device_pin_name == "INT")
-        assert int_assignment.board_pin_number in PinAssigner.GPIO_BCM_TO_PHYSICAL.values()
+        assert int_assignment.board_pin_number in pi5_board.pins_by_role()[PinRole.GPIO]
 
-    def test_single_spi_device(self):
+    def test_single_spi_device(self, pi5_board):
         """Test assigning pins for a single SPI device."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
 
         device = {
             "name": "ST7735 TFT",
@@ -156,9 +169,9 @@ class TestPinAssigner:
         assert miso.board_pin_number == 21
         assert sclk.board_pin_number == 23
 
-    def test_two_spi_devices_different_chip_selects(self):
+    def test_two_spi_devices_different_chip_selects(self, pi5_board):
         """Test that two SPI devices get different chip select pins."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
 
         devices = [
             {
@@ -201,9 +214,9 @@ class TestPinAssigner:
         assert ce0_assignments[0].board_pin_number == 24
         assert ce1_assignments[0].board_pin_number == 26
 
-    def test_three_spi_devices_warning(self):
+    def test_three_spi_devices_warning(self, pi5_board):
         """Test that more than 2 SPI devices generates a warning."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
 
         devices = [
             {
@@ -222,9 +235,9 @@ class TestPinAssigner:
         assert len(warnings) > 0
         assert any("chip select" in w.lower() for w in warnings)
 
-    def test_gpio_device(self):
+    def test_gpio_device(self, pi5_board):
         """Test assigning pins for a GPIO device."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
 
         device = {
             "name": "LED",
@@ -243,11 +256,11 @@ class TestPinAssigner:
 
         # Check that a GPIO pin was assigned
         gpio_assignment = next(a for a in assignments if a.pin_role == PinRole.GPIO)
-        assert gpio_assignment.board_pin_number in PinAssigner.GPIO_BCM_TO_PHYSICAL.values()
+        assert gpio_assignment.board_pin_number in pi5_board.pins_by_role()[PinRole.GPIO]
 
-    def test_power_distribution(self):
+    def test_power_distribution(self, pi5_board):
         """Test that power pins are distributed correctly."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
 
         # Create 3 devices that need 3.3V
         devices = [
@@ -271,9 +284,9 @@ class TestPinAssigner:
         # Power pins should cycle between available pins
         assert all(a.board_pin_number in [1, 17] for a in power_assignments)
 
-    def test_ground_distribution(self):
+    def test_ground_distribution(self, pi5_board):
         """Test that ground pins are distributed correctly."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
 
         devices = [
             {
@@ -291,11 +304,12 @@ class TestPinAssigner:
         assert all(a.pin_role == PinRole.GROUND for a in assignments)
 
         # Ground pins should be from the available list
-        assert all(a.board_pin_number in PinAssigner.GROUND_PINS for a in assignments)
+        gnd_pins = pi5_board.pins_by_role()[PinRole.GROUND]
+        assert all(a.board_pin_number in gnd_pins for a in assignments)
 
-    def test_power_overload_warning(self):
+    def test_power_overload_warning(self, pi5_board):
         """Test warning when too many devices use power."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
 
         devices = [
             {
@@ -311,9 +325,10 @@ class TestPinAssigner:
         assert len(warnings) > 0
         assert any("current" in w.lower() for w in warnings)
 
-    def test_four_pwm_devices_use_all_pwm_pins(self):
-        """PWM strategies should allocate all four supported PWM-capable pins."""
-        assigner = PinAssigner()
+    def test_four_pwm_devices_use_all_pwm_pins(self, pi5_board):
+        """PWM strategies should allocate all supported PWM-capable pins."""
+        assigner = PinAssigner(pi5_board)
+        pwm_pins = pi5_board.pins_by_role().get(PinRole.PWM, [])
 
         devices = [
             {
@@ -321,57 +336,57 @@ class TestPinAssigner:
                 "protocols": [],
                 "pins": [{"name": "SIG", "role": "PWM"}],
             }
-            for index in range(4)
+            for index in range(len(pwm_pins))
         ]
 
         assignments, warnings = assigner.assign_pins(devices)
 
-        assert len(assignments) == 4
+        assert len(assignments) == len(pwm_pins)
         assert len(warnings) == 0
-        assert {assignment.board_pin_number for assignment in assignments} == {12, 32, 33, 35}
+        assert {assignment.board_pin_number for assignment in assignments} == set(pwm_pins)
 
-    def test_general_gpio_warning_when_gpio_pool_is_exhausted(self):
+    def test_general_gpio_warning_when_gpio_pool_is_exhausted(self, pi5_board):
         """General GPIO assignment should warn when no GPIO pins remain."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
         assigner.state.available_gpio = []
 
         warnings = assigner._assign_general_pin("Exhausted", "SIG", PinRole.GPIO)
 
         assert warnings == ["Error: No GPIO pins available for Exhausted/SIG"]
 
-    def test_general_pwm_warning_when_pwm_candidates_are_exhausted(self):
+    def test_general_pwm_warning_when_pwm_candidates_are_exhausted(self, pi5_board):
         """PWM helper should warn when all PWM-capable pins are already used."""
-        assigner = PinAssigner()
-        assigner.state.used_pins.update(PinAssigner.PWM_PINS)
+        assigner = PinAssigner(pi5_board)
+        assigner.state.used_pins.update(pi5_board.pins_by_role().get(PinRole.PWM, []))
 
         warnings = assigner._assign_general_pin("PWM Device", "SIG", PinRole.PWM)
 
         assert warnings == ["Warning: No PWM pins available for PWM Device/SIG"]
 
-    def test_general_fixed_role_assignment_uses_fixed_pin(self):
+    def test_general_fixed_role_assignment_uses_fixed_pin(self, pi5_board):
         """Fixed-role pins should be assigned from the fixed mapping."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
 
         warnings = assigner._assign_general_pin("UART Device", "TX", PinRole.UART_TX)
 
         assert warnings == []
-        assert (
-            assigner.assignments[0].board_pin_number == PinAssigner.FIXED_ROLE_PINS[PinRole.UART_TX]
-        )
+        uart_tx_pin = pi5_board.pins_by_role()[PinRole.UART_TX][0]
+        assert assigner.assignments[0].board_pin_number == uart_tx_pin
 
-    def test_general_fixed_role_assignment_warns_when_pin_is_unavailable(self):
+    def test_general_fixed_role_assignment_warns_when_pin_is_unavailable(self, pi5_board):
         """Fixed-role assignment should warn when the mapped board pin is already used."""
-        assigner = PinAssigner()
-        assigner.state.used_pins.add(PinAssigner.FIXED_ROLE_PINS[PinRole.UART_TX])
+        assigner = PinAssigner(pi5_board)
+        uart_tx_pin = pi5_board.pins_by_role()[PinRole.UART_TX][0]
+        assigner.state.used_pins.add(uart_tx_pin)
 
         warnings = assigner._assign_general_pin("UART Device", "TX", PinRole.UART_TX)
 
         assert warnings == ["Warning: Fixed UART_TX pin unavailable for UART Device/TX"]
         assert assigner.assignments == []
 
-    def test_general_pin_warns_for_unsupported_role_objects(self):
+    def test_general_pin_warns_for_unsupported_role_objects(self, pi5_board):
         """Unsupported role-like objects should produce a warning instead of crashing."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
 
         class UnsupportedRole:
             value = "UNSUPPORTED"
@@ -380,9 +395,9 @@ class TestPinAssigner:
 
         assert warnings == ["Warning: Unsupported pin role UNSUPPORTED for Mystery Device/X"]
 
-    def test_mixed_devices(self):
+    def test_mixed_devices(self, pi5_board):
         """Test complex scenario with mixed I2C, SPI, and GPIO devices."""
-        assigner = PinAssigner()
+        assigner = PinAssigner(pi5_board)
 
         devices = [
             {
@@ -448,37 +463,87 @@ class TestPinAssigner:
         assert assignment.pin_role == PinRole.I2C_SDA
 
 
-class TestPinMappings:
-    """Test suite for pin mapping constants."""
+class TestBoardPinMappings:
+    """Test that board pin roles are correctly derived for Pi5."""
 
-    def test_i2c_pins(self):
-        """Test that I2C pins are correctly defined."""
-        assert PinAssigner.I2C_SDA_PIN == 3
-        assert PinAssigner.I2C_SCL_PIN == 5
+    def test_i2c_pins(self, pi5_board):
+        """Test that I2C pins are correctly derived from board."""
+        pin_map = pi5_board.pins_by_role()
+        assert pin_map[PinRole.I2C_SDA][0] == 3
+        assert pin_map[PinRole.I2C_SCL][0] == 5
 
-    def test_spi_pins(self):
-        """Test that SPI pins are correctly defined."""
-        assert PinAssigner.SPI_MOSI_PIN == 19
-        assert PinAssigner.SPI_MISO_PIN == 21
-        assert PinAssigner.SPI_SCLK_PIN == 23
-        assert PinAssigner.SPI_CE0_PIN == 24
-        assert PinAssigner.SPI_CE1_PIN == 26
+    def test_spi_pins(self, pi5_board):
+        """Test that SPI pins are correctly derived from board."""
+        pin_map = pi5_board.pins_by_role()
+        assert pin_map[PinRole.SPI_MOSI][0] == 19
+        assert pin_map[PinRole.SPI_MISO][0] == 21
+        assert pin_map[PinRole.SPI_SCLK][0] == 23
+        assert pin_map[PinRole.SPI_CE0][0] == 24
+        assert pin_map[PinRole.SPI_CE1][0] == 26
 
-    def test_power_pins(self):
-        """Test that power pins are correctly defined."""
-        assert PinAssigner.POWER_3V3_PINS == [1, 17]
-        assert PinAssigner.POWER_5V_PINS == [2, 4]
+    def test_power_pins(self, pi5_board):
+        """Test that power pins are correctly derived from board."""
+        pin_map = pi5_board.pins_by_role()
+        assert pin_map[PinRole.POWER_3V3] == [1, 17]
+        assert pin_map[PinRole.POWER_5V] == [2, 4]
 
-    def test_ground_pins(self):
-        """Test that ground pins are correctly defined."""
-        assert len(PinAssigner.GROUND_PINS) == 8
-        assert 6 in PinAssigner.GROUND_PINS
-        assert 9 in PinAssigner.GROUND_PINS
+    def test_ground_pins(self, pi5_board):
+        """Test that ground pins are correctly derived from board."""
+        pin_map = pi5_board.pins_by_role()
+        assert len(pin_map[PinRole.GROUND]) == 8
+        assert 6 in pin_map[PinRole.GROUND]
+        assert 9 in pin_map[PinRole.GROUND]
 
-    def test_gpio_bcm_mapping(self):
-        """Test that GPIO BCM to physical mapping is correct."""
-        # Test a few known mappings
-        assert PinAssigner.GPIO_BCM_TO_PHYSICAL[2] == 3
-        assert PinAssigner.GPIO_BCM_TO_PHYSICAL[3] == 5
-        assert PinAssigner.GPIO_BCM_TO_PHYSICAL[4] == 7
-        assert PinAssigner.GPIO_BCM_TO_PHYSICAL[17] == 11
+    def test_gpio_pins(self, pi5_board):
+        """Test that GPIO pins are present on the board."""
+        pin_map = pi5_board.pins_by_role()
+        gpio_pins = pin_map[PinRole.GPIO]
+        assert len(gpio_pins) > 0
+        # Verify a few known GPIO physical pins
+        assert 7 in gpio_pins  # GPIO4
+        assert 11 in gpio_pins  # GPIO17
+        assert 13 in gpio_pins  # GPIO27
+
+
+class TestPicoBoard:
+    """Test that PinAssigner works with a Pico board (board-agnostic)."""
+
+    def test_pico_gpio_device(self, pico_board):
+        """GPIO assignment on Pico should use Pico's GPIO pins."""
+        assigner = PinAssigner(pico_board)
+
+        device = {
+            "name": "LED",
+            "protocols": [],
+            "pins": [
+                {"name": "VCC", "role": "3V3"},
+                {"name": "GND", "role": "GND"},
+                {"name": "SIG", "role": "GPIO"},
+            ],
+        }
+
+        assignments, warnings = assigner.assign_pins([device])
+
+        assert len(assignments) == 3
+        gpio_assignment = next(a for a in assignments if a.pin_role == PinRole.GPIO)
+        # Verify the GPIO pin is from the Pico's pin set, not Pi5's
+        pico_gpio_pins = pico_board.pins_by_role()[PinRole.GPIO]
+        assert gpio_assignment.board_pin_number in pico_gpio_pins
+
+    def test_pico_ground_distribution(self, pico_board):
+        """Ground pins on Pico should come from Pico's GND pins."""
+        assigner = PinAssigner(pico_board)
+
+        devices = [
+            {
+                "name": f"Device {i}",
+                "protocols": [],
+                "pins": [{"name": "GND", "role": "GND"}],
+            }
+            for i in range(3)
+        ]
+
+        assignments, warnings = assigner.assign_pins(devices)
+
+        pico_gnd_pins = pico_board.pins_by_role()[PinRole.GROUND]
+        assert all(a.board_pin_number in pico_gnd_pins for a in assignments)


### PR DESCRIPTION
## Summary

Extract board pin knowledge into a shared `Board.pins_by_role()` method, replacing the MCP PinAssigner's hardcoded Raspberry Pi 5 constants. Both config_loader and MCP flows now derive pin assignments from the board's actual pin configuration.

## Problem

Pin assignment logic existed in two diverging implementations:
- `config_loader.PinAssigner`: board-agnostic, scans `board.pins` at init
- `mcp/pin_assignment.PinAssigner`: hardcoded Pi5 constants (`I2C_SDA_PIN = 3`, `GPIO_BCM_TO_PHYSICAL`, etc.)

Adding a new board required editing the MCP PinAssigner's hardcoded constants — a maintenance risk that would only grow.

## Changes

- **`Board.pins_by_role()`** — new method on `Board` that groups physical pin numbers by `PinRole`
- **config_loader `PinAssigner`** — uses `board.pins_by_role()` instead of manual loop (no behavior change)
- **MCP `PinAssigner(board)`** — takes a `Board` param, replaces all hardcoded constants with `_pin_map` lookups. GPIO pool uses physical pins directly (removes BCM indirection).
- **MCP `generate_diagram()`** — resolves `Board` object early, passes to `PinAssigner` and `ConnectionBuilder`
- **`ConnectionBuilder.build_diagram()`** — accepts optional `board` param to avoid redundant lookup
- **Tests** — all updated to pass board; added Pico board tests proving board-agnostic assignment

## Verification

- 998 tests pass
- Lint clean (`ruff check` + `ruff format`)
- CLI smoke test (`pinviz example bh1750`) renders correctly