### PR TITLE
refactor: extract PinAssigner to shared top-level module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,7 +203,7 @@ PinViz uses a consistent test structure across the codebase. Follow these patter
 ```python
 """Tests for the PinAssigner class."""
 
-from pinviz.mcp.pin_assignment import PinAssigner, PinAssignment
+from pinviz.pin_assignment import PinAssigner, PinAssignment
 from pinviz.model import PinRole
 
 

--- a/src/pinviz/config_loader.py
+++ b/src/pinviz/config_loader.py
@@ -16,7 +16,6 @@ from .diagram_builder import DiagramBuilder, DiagramOptions
 from .errors import format_config_error
 from .logging_config import get_logger
 from .model import (
-    Board,
     Connection,
     Device,
     DevicePin,
@@ -24,6 +23,7 @@ from .model import (
     PinRole,
     Point,
 )
+from .pin_assignment import PinAssigner
 from .schemas import ConnectionSchema, validate_config
 from .theme import Theme
 from .utils import is_output_pin
@@ -33,102 +33,6 @@ log = get_logger(__name__)
 
 # Maximum config file size in bytes (10MB)
 MAX_CONFIG_FILE_SIZE = 10 * 1024 * 1024
-
-
-class PinAssigner:
-    """
-    Manages automatic pin assignment for role-based connections.
-
-    Distributes connections across multiple available pins of the same role
-    to avoid multiple wires on a single pin (better for soldering/connections).
-
-    Example:
-        >>> assigner = PinAssigner(board)
-        >>> # First GND connection gets pin 14
-        >>> pin1 = assigner.assign_pin("GND")
-        >>> # Second GND connection gets pin 19 (next available GND)
-        >>> pin2 = assigner.assign_pin("GND")
-    """
-
-    def __init__(self, board: Board) -> None:
-        """
-        Initialize pin assigner with a board.
-
-        Args:
-            board: Board object with pins to assign
-        """
-        self.board = board
-        # Track which pins have been assigned: role -> list of assigned pin numbers
-        self._role_assignment_index: dict[PinRole, int] = {}
-        # Build lookup: role -> list of available pin numbers
-        self._pins_by_role = board.pins_by_role()
-
-        log.debug(
-            "pin_assigner_initialized",
-            board=board.name,
-            role_counts={role.value: len(pins) for role, pins in self._pins_by_role.items()},
-        )
-
-    def assign_pin(self, role: str | PinRole) -> int:
-        """
-        Assign next available pin of the specified role.
-
-        Uses round-robin distribution to spread connections across multiple
-        pins of the same role.
-
-        Args:
-            role: Pin role (e.g., "GND", "3V3") as string or PinRole enum
-
-        Returns:
-            Physical pin number
-
-        Raises:
-            ValueError: If no pins of the specified role are available
-        """
-        # Convert string to PinRole
-        if isinstance(role, str):
-            try:
-                pin_role = PinRole(role.upper())
-            except ValueError:
-                # Try without upper() in case it's already correct case
-                try:
-                    pin_role = PinRole(role)
-                except ValueError as e:
-                    raise ValueError(
-                        f"Invalid pin role '{role}'. Must be one of: "
-                        f"{', '.join(r.value for r in PinRole)}"
-                    ) from e
-        else:
-            pin_role = role
-
-        # Check if this role exists on the board
-        if pin_role not in self._pins_by_role:
-            available_roles = sorted(r.value for r in self._pins_by_role)
-            raise ValueError(
-                f"Board '{self.board.name}' has no pins with role '{pin_role.value}'. "
-                f"Available roles: {', '.join(available_roles)}"
-            )
-
-        available_pins = self._pins_by_role[pin_role]
-
-        # Get current index for this role (default to 0)
-        current_index = self._role_assignment_index.get(pin_role, 0)
-
-        # Round-robin: cycle through available pins
-        assigned_pin = available_pins[current_index % len(available_pins)]
-
-        # Update index for next assignment
-        self._role_assignment_index[pin_role] = current_index + 1
-
-        log.debug(
-            "pin_assigned",
-            role=pin_role.value,
-            assigned_pin=assigned_pin,
-            available_count=len(available_pins),
-            assignment_index=current_index + 1,
-        )
-
-        return assigned_pin
 
 
 class ConfigLoader:

--- a/src/pinviz/mcp/connection_builder.py
+++ b/src/pinviz/mcp/connection_builder.py
@@ -2,8 +2,8 @@
 
 from pinviz.board_selection import AliasBoardSelectionStrategy, BoardSelectionStrategy
 from pinviz.diagram_builder import DiagramBuilder
-from pinviz.mcp.pin_assignment import PinAssignment
 from pinviz.model import DEFAULT_COLORS, Board, Connection, Device, Diagram
+from pinviz.pin_assignment import PinAssignment
 
 from .adapters import McpDeviceAdapter
 

--- a/src/pinviz/mcp/server.py
+++ b/src/pinviz/mcp/server.py
@@ -158,9 +158,9 @@ def generate_diagram(prompt: str, output_format: str = "yaml", title: str | None
         - The YAML includes full device pin definitions required by the pinviz CLI
     """
     from pinviz.board_selection import AliasBoardSelectionStrategy
+    from pinviz.pin_assignment import PinAssigner
 
     from .parser import PromptParser
-    from .pin_assignment import PinAssigner
 
     try:
         # Step 1: Parse natural language prompt

--- a/src/pinviz/pin_assignment.py
+++ b/src/pinviz/pin_assignment.py
@@ -1,7 +1,8 @@
 """
-Intelligent Pin Assignment for PinViz MCP Server.
+Intelligent Pin Assignment for PinViz.
 
-This module implements algorithms for automatic pin assignment, handling:
+Shared module used by both ConfigLoader (YAML/JSON configs) and MCP server.
+Implements algorithms for automatic pin assignment, handling:
 - GPIO availability tracking
 - I2C bus sharing
 - SPI chip select allocation
@@ -138,6 +139,120 @@ class PinAssigner:
             "SPI": SPIPinAssignmentStrategy(),
         }
         self._default_strategy = DefaultPinAssignmentStrategy()
+
+    def assign_pin(self, role: str | PinRole) -> int:
+        """Assign next available pin for the given role.
+
+        Incremental interface for ConfigLoader's connection-by-connection
+        parsing. Handles bus sharing (I2C/SPI pins are cached and reused)
+        and round-robin distribution for power/ground pins.
+
+        Args:
+            role: Pin role as string or PinRole enum.
+
+        Returns:
+            Physical pin number.
+
+        Raises:
+            ValueError: If no pins available for the role.
+        """
+        if isinstance(role, str):
+            try:
+                pin_role = PinRole(role.upper())
+            except ValueError:
+                try:
+                    pin_role = PinRole(role)
+                except ValueError as e:
+                    raise ValueError(
+                        f"Invalid pin role '{role}'. Must be one of: "
+                        f"{', '.join(r.value for r in PinRole)}"
+                    ) from e
+        else:
+            pin_role = role
+
+        # I2C bus sharing — return cached pin if already assigned
+        if pin_role == PinRole.I2C_SDA:
+            if self.state.i2c_sda_pin is None:
+                sda_pins = self._pin_map.get(PinRole.I2C_SDA, [])
+                if not sda_pins:
+                    raise ValueError("Board has no I2C SDA pins")
+                self.state.i2c_sda_pin = sda_pins[0]
+                self.state.used_pins.add(self.state.i2c_sda_pin)
+            return self.state.i2c_sda_pin
+        if pin_role == PinRole.I2C_SCL:
+            if self.state.i2c_scl_pin is None:
+                scl_pins = self._pin_map.get(PinRole.I2C_SCL, [])
+                if not scl_pins:
+                    raise ValueError("Board has no I2C SCL pins")
+                self.state.i2c_scl_pin = scl_pins[0]
+                self.state.used_pins.add(self.state.i2c_scl_pin)
+            return self.state.i2c_scl_pin
+
+        # SPI bus sharing — shared bus lines, chip selects consumed
+        if pin_role == PinRole.SPI_MOSI:
+            if self.state.spi_mosi_pin is None:
+                pins = self._pin_map.get(PinRole.SPI_MOSI, [])
+                if not pins:
+                    raise ValueError("Board has no SPI MOSI pins")
+                self.state.spi_mosi_pin = pins[0]
+                self.state.used_pins.add(self.state.spi_mosi_pin)
+            return self.state.spi_mosi_pin
+        if pin_role == PinRole.SPI_MISO:
+            if self.state.spi_miso_pin is None:
+                pins = self._pin_map.get(PinRole.SPI_MISO, [])
+                if not pins:
+                    raise ValueError("Board has no SPI MISO pins")
+                self.state.spi_miso_pin = pins[0]
+                self.state.used_pins.add(self.state.spi_miso_pin)
+            return self.state.spi_miso_pin
+        if pin_role == PinRole.SPI_SCLK:
+            if self.state.spi_sclk_pin is None:
+                pins = self._pin_map.get(PinRole.SPI_SCLK, [])
+                if not pins:
+                    raise ValueError("Board has no SPI SCLK pins")
+                self.state.spi_sclk_pin = pins[0]
+                self.state.used_pins.add(self.state.spi_sclk_pin)
+            return self.state.spi_sclk_pin
+        if pin_role in (PinRole.SPI_CE0, PinRole.SPI_CE1):
+            pin = self._assign_from_candidates(self._pin_map.get(pin_role, []))
+            if pin is None:
+                raise ValueError(f"No {pin_role.value} pins available")
+            return pin
+
+        # GPIO — consumed, never reused
+        if pin_role == PinRole.GPIO:
+            pin = self._assign_gpio_pin()
+            if pin is None:
+                raise ValueError("No GPIO pins available")
+            return pin
+
+        # PWM
+        if pin_role == PinRole.PWM:
+            pin = self._assign_from_candidates(self._pin_map.get(PinRole.PWM, []))
+            if pin is None:
+                raise ValueError("No PWM pins available")
+            return pin
+
+        # Power rails — round-robin
+        if pin_role in (PinRole.POWER_3V3, PinRole.POWER_5V):
+            return self._assign_power_pin(pin_role)
+
+        # Ground — round-robin
+        if pin_role == PinRole.GROUND:
+            return self._assign_ground_pin()
+
+        # Fixed roles (UART, PCM, etc.)
+        if pin_role in self.FIXED_ROLES:
+            pin = self._assign_fixed_role_pin(pin_role)
+            if pin is None:
+                raise ValueError(f"No {pin_role.value} pins available")
+            return pin
+
+        # Fallback — try to find any pin with this role
+        pin = self._assign_from_candidates(self._pin_map.get(pin_role, []))
+        if pin is None:
+            raise ValueError(f"No pins available for role '{pin_role.value}'")
+        return pin
 
     def assign_pins(self, devices_data: list[dict]) -> tuple[list[PinAssignment], list[str]]:
         """

--- a/tests/test_connection_builder.py
+++ b/tests/test_connection_builder.py
@@ -4,8 +4,8 @@ from pinviz.mcp.connection_builder import (
     ConnectionBuilder,
     build_diagram_from_assignments,
 )
-from pinviz.mcp.pin_assignment import PinAssignment
 from pinviz.model import Diagram, PinRole
+from pinviz.pin_assignment import PinAssignment
 
 
 class TestConnectionBuilder:

--- a/tests/test_integration_phase2.py
+++ b/tests/test_integration_phase2.py
@@ -4,8 +4,8 @@ from pinviz import boards
 from pinviz.mcp.connection_builder import ConnectionBuilder
 from pinviz.mcp.device_manager import DeviceManager
 from pinviz.mcp.parser import PromptParser
-from pinviz.mcp.pin_assignment import PinAssigner
 from pinviz.model import Diagram
+from pinviz.pin_assignment import PinAssigner
 from pinviz.render_svg import SVGRenderer
 
 

--- a/tests/test_integration_real_world.py
+++ b/tests/test_integration_real_world.py
@@ -18,7 +18,7 @@ from pinviz import boards
 from pinviz.mcp.connection_builder import ConnectionBuilder
 from pinviz.mcp.device_manager import DeviceManager
 from pinviz.mcp.parser import PromptParser
-from pinviz.mcp.pin_assignment import PinAssigner
+from pinviz.pin_assignment import PinAssigner
 from pinviz.render_svg import SVGRenderer
 
 # Fixtures

--- a/tests/test_mcp_local.py
+++ b/tests/test_mcp_local.py
@@ -13,7 +13,7 @@ try:
     from pinviz.mcp.connection_builder import ConnectionBuilder
     from pinviz.mcp.device_manager import DeviceManager
     from pinviz.mcp.parser import PromptParser
-    from pinviz.mcp.pin_assignment import PinAssigner
+    from pinviz.pin_assignment import PinAssigner
     from pinviz.render_svg import SVGRenderer
 except ModuleNotFoundError:
     # Allow running this file directly without editable install.
@@ -23,7 +23,7 @@ except ModuleNotFoundError:
     from pinviz.mcp.connection_builder import ConnectionBuilder
     from pinviz.mcp.device_manager import DeviceManager
     from pinviz.mcp.parser import PromptParser
-    from pinviz.mcp.pin_assignment import PinAssigner
+    from pinviz.pin_assignment import PinAssigner
     from pinviz.render_svg import SVGRenderer
 
 

--- a/tests/test_pin_assignment.py
+++ b/tests/test_pin_assignment.py
@@ -3,8 +3,8 @@
 import pytest
 
 from pinviz import boards
-from pinviz.mcp.pin_assignment import PinAllocationState, PinAssigner, PinAssignment
 from pinviz.model import PinRole
+from pinviz.pin_assignment import PinAllocationState, PinAssigner, PinAssignment
 
 
 @pytest.fixture()


### PR DESCRIPTION
Move PinAssigner from `mcp/pin_assignment.py` to `pinviz/pin_assignment.py` so both ConfigLoader and MCP server share one implementation.

## Changes
- Add `assign_pin(role)` incremental interface for ConfigLoader with I2C/SPI bus sharing and GPIO consumption semantics
- Remove ConfigLoader's old 94-line round-robin PinAssigner
- Delete `mcp/pin_assignment.py` (all code now in `pinviz/pin_assignment.py`)
- Update all imports (server.py, connection_builder.py, 5 test files, docs)

## Design decisions
- **Unified module**: Both CLI (ConfigLoader) and MCP server import from `pinviz.pin_assignment`
- **Two entry points**: `assign_pin(role) → int` for incremental use, `assign_pins(devices) → (assignments, warnings)` for batch
- **Bus-aware**: I2C/SPI pins are cached and reused (bus sharing), GPIO pins consumed (never reused)
- **Behavior change**: GPIO assignment switches from round-robin to pop-and-consume (correct physical semantics)

998 tests pass, lint clean.