### PR TITLE
fix: add cross-validation to both assembly paths

### DIFF
--- a/src/pinviz/config_loader.py
+++ b/src/pinviz/config_loader.py
@@ -27,7 +27,7 @@ from .pin_assignment import PinAssigner
 from .schemas import ConnectionSchema, validate_config
 from .theme import Theme
 from .utils import is_output_pin
-from .validation import ValidationIssue, ValidationLevel
+from .validation import DiagramValidator, ValidationIssue, ValidationLevel
 
 log = get_logger(__name__)
 
@@ -269,6 +269,17 @@ class ConfigLoader:
             .with_options(options)
             .build()
         )
+
+        # Run electrical safety validation (voltage, pin compatibility, etc.)
+        electrical_issues = DiagramValidator().validate(diagram)
+        electrical_warnings = [
+            issue
+            for issue in electrical_issues
+            if issue.level in (ValidationLevel.WARNING, ValidationLevel.ERROR)
+        ]
+
+        if electrical_warnings and self.emit_validation_output:
+            self._report_validation_warnings(electrical_warnings)
 
         log.info(
             "diagram_config_loaded",

--- a/src/pinviz/mcp/server.py
+++ b/src/pinviz/mcp/server.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
+from pinviz.connection_graph import ConnectionGraph
 from pinviz.validation import DiagramValidator, ValidationLevel
 
 from .connection_builder import ConnectionBuilder
@@ -223,7 +224,17 @@ def generate_diagram(prompt: str, output_format: str = "yaml", title: str | None
             ),
         )
 
-        # Validate the diagram
+        # Validate the diagram — structural + electrical
+        # Structural: cycles, orphans
+        graph = ConnectionGraph(diagram.devices, diagram.connections)
+        cycles = graph.detect_cycles()
+        structural_issues = []
+        if cycles:
+            for cycle in cycles:
+                cycle_path = " → ".join(cycle)
+                structural_issues.append(f"Cycle detected: {cycle_path}")
+
+        # Electrical: voltage, pin compatibility, current limits
         validator = DiagramValidator()
         validation_issues = validator.validate(diagram)
 
@@ -231,6 +242,9 @@ def generate_diagram(prompt: str, output_format: str = "yaml", title: str | None
         validation_errors = [i for i in validation_issues if i.level == ValidationLevel.ERROR]
         validation_warnings = [i for i in validation_issues if i.level == ValidationLevel.WARNING]
         validation_infos = [i for i in validation_issues if i.level == ValidationLevel.INFO]
+
+        # Include structural issues as errors
+        all_error_strings = structural_issues + [str(e) for e in validation_errors]
 
         # Step 4: Generate diagram output
         diagram_title = diagram.title
@@ -264,20 +278,20 @@ def generate_diagram(prompt: str, output_format: str = "yaml", title: str | None
             result["not_found"] = not_found
 
         # Add validation results
-        if validation_issues:
+        if validation_issues or structural_issues:
             result["validation"] = {
-                "total_issues": len(validation_issues),
-                "errors": [str(e) for e in validation_errors],
+                "total_issues": len(validation_issues) + len(structural_issues),
+                "errors": all_error_strings,
                 "warnings": [str(w) for w in validation_warnings],
                 "info": [str(i) for i in validation_infos],
             }
 
             # Update status if there are errors
-            if validation_errors:
+            if all_error_strings:
                 result["status"] = "error"
                 result["validation_status"] = "failed"
                 result["validation_message"] = (
-                    f"Diagram has {len(validation_errors)} validation error(s). "
+                    f"Diagram has {len(all_error_strings)} validation error(s). "
                     "These issues could cause hardware damage or circuit malfunction. "
                     "Review the 'validation.errors' field for details."
                 )

--- a/tests/test_mcp_local.py
+++ b/tests/test_mcp_local.py
@@ -134,6 +134,22 @@ def test_database_summary():
     assert len(dm.search_devices()) > 0
 
 
+def test_generate_diagram_includes_validation():
+    """generate_diagram() should include structural + electrical validation."""
+    import json
+
+    from pinviz.mcp.server import generate_diagram
+
+    result_json = generate_diagram("Connect BME280 sensor", output_format="summary")
+    result = json.loads(result_json)
+
+    assert result["status"] == "success"
+    assert "validation" in result
+    assert "errors" in result["validation"]
+    assert "warnings" in result["validation"]
+    assert "validation_status" in result
+
+
 def main():
     """Run all MCP local tests manually."""
     print("=" * 70)


### PR DESCRIPTION
Both diagram assembly paths were missing each other's validation:

- **ConfigLoader** had structural checks (cycles, orphans) but no electrical safety checks
- **MCP server** had electrical safety checks but no structural checks

## Changes
- ConfigLoader now runs `DiagramValidator` after `build()` — electrical issues emitted as warnings (non-blocking)
- MCP server now runs `ConnectionGraph` before `DiagramValidator` — cycles included in `validation.errors` response

998 tests pass, lint clean.