### PR TITLE
docs: add ESP32-S3 CAN transceiver example

### DIFF
--- a/docs/guide/examples-esp.md
+++ b/docs/guide/examples-esp.md
@@ -1,6 +1,6 @@
 # ESP32 and ESP8266 Examples
 
-Examples for ESP32 DevKit V1, ESP8266 NodeMCU, and Wemos D1 Mini boards.
+Examples for ESP32 DevKit V1, ESP32-S3-DevKitC-1, ESP8266 NodeMCU, and Wemos D1 Mini boards.
 
 → [All examples index](examples.md) | [Raspberry Pi](examples-raspberry-pi.md) | [Components](examples-components.md) | [Pico](examples-pico.md) | [Multi-Tier](examples-multi-tier.md)
 
@@ -91,6 +91,61 @@ Single BME280 sensor on ESP32 DevKit V1.
 ![ESP32 I2C Sensor](https://raw.githubusercontent.com/nordstad/PinViz/main/images/esp32_example.svg)
 
 **Key Features:** I2C connection on GPIO21 (SDA) and GPIO22 (SCL), 3.3V power.
+
+---
+
+## ESP32-S3 CAN (TWAI) via SN65HVD230
+
+SN65HVD230 CAN transceiver on the ESP32-S3-DevKitC-1 (44-pin dual-sided). The
+ESP32-S3's TWAI controller drives the bus through the transceiver: CAN_TX
+(GPIO43) → `CTX` driver input, CAN_RX (GPIO44) ← `CRX` receiver output.
+
+**Configuration:** [`examples/esp32_s3_can_transceiver.yaml`](https://github.com/nordstad/PinViz/blob/main/examples/esp32_s3_can_transceiver.yaml)
+
+```yaml
+title: ESP32-S3 CAN (TWAI) via SN65HVD230
+board: esp32_s3_devkitc1
+theme: light
+
+devices:
+  - type: sn65hvd230
+    name: SN65HVD230 CAN Transceiver
+
+connections:
+  # 3V3 rail  (physical pin 1  -> GPIO/rail 3V3)
+  - board_pin: 1
+    device: SN65HVD230 CAN Transceiver
+    device_pin: "3V3"
+    color: red
+  # GND       (physical pin 2)
+  - board_pin: 2
+    device: SN65HVD230 CAN Transceiver
+    device_pin: "GND"
+    color: black
+  # CAN_TX = GPIO43 (physical pin 4) -> transceiver CTX (driver input)
+  - board_pin: 4
+    device: SN65HVD230 CAN Transceiver
+    device_pin: "CTX"
+    color: blue
+  # CAN_RX = GPIO44 (physical pin 6) -> transceiver CRX (receiver output)
+  - board_pin: 6
+    device: SN65HVD230 CAN Transceiver
+    device_pin: "CRX"
+    color: green
+```
+
+**Generate:**
+
+```bash
+pinviz render examples/esp32_s3_can_transceiver.yaml -o esp32_s3_can.svg
+```
+
+**Result:**
+
+![ESP32-S3 CAN Transceiver](https://raw.githubusercontent.com/nordstad/PinViz/main/images/esp32_s3_can_transceiver.svg)
+
+**Board aliases:** `esp32_s3_devkitc1`, `esp32s3`, `esp32_s3`
+(use `esp32_s3_devkitc1_schematic` for the artwork-free variant)
 
 ---
 

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -23,7 +23,7 @@ Explore example diagrams and configurations organised by board and feature.
 | [Raspberry Pi](examples-raspberry-pi.md) | Wire visibility, BH1750 I2C sensor, traffic light, multi-device, specs table, dark mode |
 | [Inline Components](examples-components.md) | LED + resistor, decoupling capacitor, flyback diode, all component types |
 | [Raspberry Pi Pico](examples-pico.md) | Pico LED, Pico BME280, multi-LED with specs, dark mode |
-| [ESP32 / ESP8266](examples-esp.md) | ESP32 weather station, NodeMCU LEDs, Wemos D1 Mini OLED |
+| [ESP32 / ESP8266](examples-esp.md) | ESP32 weather station, ESP32-S3 CAN transceiver, NodeMCU LEDs, Wemos D1 Mini OLED |
 | [Multi-Tier Connections](examples-multi-tier.md) | Motor control (L293D), relay control, Pico power chain |
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -169,6 +169,10 @@ Demonstrates safe control of high-voltage devices:
 - **pico_bme280.yaml** - BME280 sensor on Pico
 - **pico_leds_with_specs.yaml** - Multiple LEDs with specifications on Pico
 
+#### ESP32
+
+- **esp32_s3_can_transceiver.yaml** - SN65HVD230 CAN (TWAI) transceiver on ESP32-S3-DevKitC-1
+
 ## Python API Examples
 
 Some examples also include Python API equivalents:

--- a/images/esp32_s3_can_transceiver.svg
+++ b/images/esp32_s3_can_transceiver.svg
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="570.0" height="615.4" viewBox="0 0 570.0 615.4">
+<defs>
+</defs>
+<rect x="0" y="0" width="570.0" height="615.4" fill="white" />
+<text x="285.0" y="25" font-size="20" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">ESP32-S3 CAN (TWAI) via SN65HVD230</text>
+<g transform="translate(40.0, 130.0) scale(1.7)">
+<rect x="1.0" y="1.0" width="118.0" height="260.0" rx="7" ry="7" fill="#1b1b20" stroke="#3a3a42" stroke-width="1.2" />
+<rect x="5.0" y="5.0" width="110.0" height="252.0" rx="5" ry="5" fill="none" stroke="#2c2c34" stroke-width="0.5" />
+<circle cx="9.0" cy="9.0" r="3.6" fill="#0d0d10" stroke="#9a9aa0" stroke-width="1" />
+<circle cx="9.0" cy="9.0" r="2.0" fill="#050506" />
+<circle cx="111.0" cy="9.0" r="3.6" fill="#0d0d10" stroke="#9a9aa0" stroke-width="1" />
+<circle cx="111.0" cy="9.0" r="2.0" fill="#050506" />
+<circle cx="9.0" cy="251.0" r="3.6" fill="#0d0d10" stroke="#9a9aa0" stroke-width="1" />
+<circle cx="9.0" cy="251.0" r="2.0" fill="#050506" />
+<circle cx="111.0" cy="251.0" r="3.6" fill="#0d0d10" stroke="#9a9aa0" stroke-width="1" />
+<circle cx="111.0" cy="251.0" r="2.0" fill="#050506" />
+<rect x="47.0" y="-6.5" width="26.0" height="17.5" rx="2.6" fill="#d3d6dc" stroke="#7d818a" stroke-width="0.9" />
+<rect x="48.5" y="-4.9" width="23.0" height="14.3" rx="1.6" fill="none" stroke="#b9bdc4" stroke-width="0.5" />
+<rect x="48.5" y="11.0" width="3.0" height="2.4" rx="0.4" fill="#b7bac0" />
+<rect x="68.5" y="11.0" width="3.0" height="2.4" rx="0.4" fill="#b7bac0" />
+<rect x="18.0" y="17.0" width="12.0" height="9.0" rx="1.2" fill="#2b2b33" stroke="#565660" stroke-width="0.5" />
+<rect x="21.5" y="19.0" width="5.0" height="5.0" rx="0.8" fill="#9a9aa4" />
+<text x="24.0" y="31.5" font-size="3.0" font-family="Arial, sans-serif" fill="#8f8f98" text-anchor="middle">BOOT</text>
+<rect x="90.0" y="17.0" width="12.0" height="9.0" rx="1.2" fill="#2b2b33" stroke="#565660" stroke-width="0.5" />
+<rect x="93.5" y="19.0" width="5.0" height="5.0" rx="0.8" fill="#9a9aa4" />
+<text x="96.0" y="31.5" font-size="3.0" font-family="Arial, sans-serif" fill="#8f8f98" text-anchor="middle">RST</text>
+<rect x="43.0" y="18.5" width="5.0" height="5.0" rx="0.6" fill="#f2f2f5" stroke="#8a8a90" stroke-width="0.4" />
+<rect x="44.2" y="19.7" width="2.6" height="2.6" rx="0.4" fill="#9fd0ff" />
+<text x="45.5" y="28.5" font-size="2.6" font-family="Arial, sans-serif" fill="#7f7f88" text-anchor="middle">RGB</text>
+<rect x="34.0" y="52.0" width="52.0" height="104.0" rx="2.5" fill="#bfc3c9" stroke="#7a7e86" stroke-width="1" />
+<rect x="35.6" y="53.6" width="48.8" height="100.8" rx="1.8" fill="none" stroke="#9aa0a8" stroke-width="0.5" />
+<rect x="40.0" y="56.0" width="40.0" height="15.0" rx="1" fill="#d7dbe0" stroke="#a7adb5" stroke-width="0.5" />
+<path d="M43.0,68.0 l3,-9 l3,9" fill="none" stroke="#9aa0a8" stroke-width="0.6" />
+<path d="M49.0,68.0 l3,-9 l3,9" fill="none" stroke="#9aa0a8" stroke-width="0.6" />
+<path d="M55.0,68.0 l3,-9 l3,9" fill="none" stroke="#9aa0a8" stroke-width="0.6" />
+<path d="M61.0,68.0 l3,-9 l3,9" fill="none" stroke="#9aa0a8" stroke-width="0.6" />
+<path d="M67.0,68.0 l3,-9 l3,9" fill="none" stroke="#9aa0a8" stroke-width="0.6" />
+<path d="M73.0,68.0 l3,-9 l3,9" fill="none" stroke="#9aa0a8" stroke-width="0.6" />
+<text x="60.0" y="94.0" font-size="6.4" font-family="Arial, sans-serif" font-weight="bold" fill="#3c3f45" text-anchor="middle">ESP32-S3</text>
+<text x="60.0" y="104.0" font-size="4.4" font-family="Arial, sans-serif" fill="#4c4f55" text-anchor="middle">WROOM-1</text>
+<text x="60.0" y="142.0" font-size="3.2" font-family="Arial, sans-serif" fill="#6a6d75" text-anchor="middle">FCC ID  2AC7Z</text>
+<rect x="7.0" y="37.0" width="10.0" height="203.2" rx="1.5" fill="#0b0b0d" stroke="#33333a" stroke-width="0.5" />
+<rect x="103.0" y="37.0" width="10.0" height="203.2" rx="1.5" fill="#0b0b0d" stroke="#33333a" stroke-width="0.5" />
+<circle cx="12.0" cy="42.0" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="42.0" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="43.4" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">3V3</text>
+<text x="101.5" y="43.4" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">GND</text>
+<circle cx="12.0" cy="51.2" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="51.2" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="52.6" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">3V3</text>
+<text x="101.5" y="52.6" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">TX</text>
+<circle cx="12.0" cy="60.4" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="60.4" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="61.8" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">RST</text>
+<text x="101.5" y="61.8" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">RX</text>
+<circle cx="12.0" cy="69.6" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="69.6" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="71.0" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO4</text>
+<text x="101.5" y="71.0" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO1</text>
+<circle cx="12.0" cy="78.8" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="78.8" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="80.2" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO5</text>
+<text x="101.5" y="80.2" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO2</text>
+<circle cx="12.0" cy="88.0" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="88.0" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="89.4" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO6</text>
+<text x="101.5" y="89.4" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO42</text>
+<circle cx="12.0" cy="97.19999999999999" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="97.19999999999999" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="98.6" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO7</text>
+<text x="101.5" y="98.6" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO41</text>
+<circle cx="12.0" cy="106.39999999999999" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="106.39999999999999" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="107.8" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO15</text>
+<text x="101.5" y="107.8" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO40</text>
+<circle cx="12.0" cy="115.6" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="115.6" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="117.0" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO16</text>
+<text x="101.5" y="117.0" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO39</text>
+<circle cx="12.0" cy="124.8" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="124.8" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="126.2" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO17</text>
+<text x="101.5" y="126.2" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO38</text>
+<circle cx="12.0" cy="134.0" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="134.0" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="135.4" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO18</text>
+<text x="101.5" y="135.4" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO37</text>
+<circle cx="12.0" cy="143.2" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="143.2" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="144.6" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO8</text>
+<text x="101.5" y="144.6" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO36</text>
+<circle cx="12.0" cy="152.39999999999998" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="152.39999999999998" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="153.79999999999998" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO3</text>
+<text x="101.5" y="153.79999999999998" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO35</text>
+<circle cx="12.0" cy="161.6" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="161.6" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="163.0" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO46</text>
+<text x="101.5" y="163.0" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO0</text>
+<circle cx="12.0" cy="170.79999999999998" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="170.79999999999998" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="172.2" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO9</text>
+<text x="101.5" y="172.2" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO45</text>
+<circle cx="12.0" cy="180.0" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="180.0" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="181.4" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO10</text>
+<text x="101.5" y="181.4" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO48</text>
+<circle cx="12.0" cy="189.2" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="189.2" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="190.6" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO11</text>
+<text x="101.5" y="190.6" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO47</text>
+<circle cx="12.0" cy="198.39999999999998" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="198.39999999999998" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="199.79999999999998" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO12</text>
+<text x="101.5" y="199.79999999999998" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO21</text>
+<circle cx="12.0" cy="207.6" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="207.6" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="209.0" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO13</text>
+<text x="101.5" y="209.0" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO20</text>
+<circle cx="12.0" cy="216.79999999999998" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="216.79999999999998" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="218.2" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">IO14</text>
+<text x="101.5" y="218.2" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">IO19</text>
+<circle cx="12.0" cy="226.0" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="226.0" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="227.4" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">5V</text>
+<text x="101.5" y="227.4" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">GND</text>
+<circle cx="12.0" cy="235.2" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<circle cx="108.0" cy="235.2" r="4.4" fill="#d8b24a" stroke="#8a6f22" stroke-width="0.5" />
+<text x="18.5" y="236.6" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="start">GND</text>
+<text x="101.5" y="236.6" font-size="4.0" font-family="Consolas, Menlo, monospace" fill="#e9e9ef" text-anchor="end">GND</text>
+</g>
+<text x="142.0" y="595.4" font-size="14" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">ESP32-S3-DevKitC-1</text>
+<circle cx="60.4" cy="201.39999999999998" r="4.5" fill="#FFA500" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="59.05" y="202.89999999999998" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">1</text>
+<circle cx="223.6" cy="201.39999999999998" r="4.5" fill="#D3D3D3" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="222.25" y="202.89999999999998" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">2</text>
+<circle cx="60.4" cy="217.04000000000002" r="4.5" fill="#FFA500" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="59.05" y="218.54000000000002" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">3</text>
+<circle cx="223.6" cy="217.04000000000002" r="4.5" fill="#0000FF" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="222.25" y="218.54000000000002" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#FFFFFF">4</text>
+<circle cx="60.4" cy="232.68" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="59.05" y="234.18" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">5</text>
+<circle cx="223.6" cy="232.68" r="4.5" fill="#0000FF" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="222.25" y="234.18" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#FFFFFF">6</text>
+<circle cx="60.4" cy="248.32" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="59.05" y="249.82" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">7</text>
+<circle cx="223.6" cy="248.32" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="222.25" y="249.82" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">8</text>
+<circle cx="60.4" cy="263.96" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="59.05" y="265.46" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">9</text>
+<circle cx="223.6" cy="263.96" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="265.46" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">10</text>
+<circle cx="60.4" cy="279.6" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="281.1" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">11</text>
+<circle cx="223.6" cy="279.6" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="281.1" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">12</text>
+<circle cx="60.4" cy="295.24" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="296.74" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">13</text>
+<circle cx="223.6" cy="295.24" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="296.74" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">14</text>
+<circle cx="60.4" cy="310.88" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="312.38" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">15</text>
+<circle cx="223.6" cy="310.88" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="312.38" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">16</text>
+<circle cx="60.4" cy="326.52" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="328.02" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">17</text>
+<circle cx="223.6" cy="326.52" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="328.02" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">18</text>
+<circle cx="60.4" cy="342.15999999999997" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="343.65999999999997" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">19</text>
+<circle cx="223.6" cy="342.15999999999997" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="343.65999999999997" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">20</text>
+<circle cx="60.4" cy="357.79999999999995" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="359.29999999999995" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">21</text>
+<circle cx="223.6" cy="357.79999999999995" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="359.29999999999995" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">22</text>
+<circle cx="60.4" cy="373.43999999999994" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="374.93999999999994" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">23</text>
+<circle cx="223.6" cy="373.43999999999994" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="374.93999999999994" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">24</text>
+<circle cx="60.4" cy="389.0799999999999" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="390.5799999999999" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">25</text>
+<circle cx="223.6" cy="389.0799999999999" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="390.5799999999999" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">26</text>
+<circle cx="60.4" cy="404.71999999999997" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="406.21999999999997" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">27</text>
+<circle cx="223.6" cy="404.71999999999997" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="406.21999999999997" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">28</text>
+<circle cx="60.4" cy="420.35999999999996" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="421.85999999999996" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">29</text>
+<circle cx="223.6" cy="420.35999999999996" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="421.85999999999996" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">30</text>
+<circle cx="60.4" cy="436.0" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="437.5" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">31</text>
+<circle cx="223.6" cy="436.0" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="437.5" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">32</text>
+<circle cx="60.4" cy="451.64" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="453.14" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">33</text>
+<circle cx="223.6" cy="451.64" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="453.14" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">34</text>
+<circle cx="60.4" cy="467.28" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="468.78" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">35</text>
+<circle cx="223.6" cy="467.28" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="468.78" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">36</text>
+<circle cx="60.4" cy="482.91999999999996" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="484.41999999999996" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">37</text>
+<circle cx="223.6" cy="482.91999999999996" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="484.41999999999996" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">38</text>
+<circle cx="60.4" cy="498.55999999999995" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="500.05999999999995" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">39</text>
+<circle cx="223.6" cy="498.55999999999995" r="4.5" fill="#00FF00" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="500.05999999999995" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">40</text>
+<circle cx="60.4" cy="514.2" r="4.5" fill="#FF0000" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="515.7" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">41</text>
+<circle cx="223.6" cy="514.2" r="4.5" fill="#D3D3D3" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="515.7" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">42</text>
+<circle cx="60.4" cy="529.8399999999999" r="4.5" fill="#D3D3D3" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="57.699999999999996" y="531.3399999999999" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">43</text>
+<circle cx="223.6" cy="529.8399999999999" r="4.5" fill="#D3D3D3" stroke="#333" stroke-width="0.5" opacity="0.95" />
+<text x="220.9" y="531.3399999999999" font-size="4.5" font-family="Arial, sans-serif" font-weight="bold" fill="#000000">44</text>
+<path d="M 60.40,201.40 C 123.88,157.66 322.40,206.73 440.00,223.13" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 60.40,201.40 C 123.88,157.66 322.40,206.73 440.00,223.13" stroke="#FF0000" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<circle cx="60.4" cy="201.39999999999998" r="4.0" fill="white" />
+<circle cx="60.4" cy="201.39999999999998" r="3.0" fill="#FF0000" />
+<path d="M 223.60,232.68 C 245.32,276.68 339.20,269.63 440.00,253.13" stroke="#2C2C2C" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 223.60,232.68 C 245.32,276.68 339.20,269.63 440.00,253.13" stroke="#00FF00" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<circle cx="223.6" cy="232.68" r="4.0" fill="white" />
+<circle cx="223.6" cy="232.68" r="3.0" fill="#00FF00" />
+<path d="M 223.60,217.04 C 242.92,231.44 333.60,248.53 440.00,243.13" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 223.60,217.04 C 242.92,231.44 333.60,248.53 440.00,243.13" stroke="#0000FF" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<circle cx="223.6" cy="217.04000000000002" r="4.0" fill="white" />
+<circle cx="223.6" cy="217.04000000000002" r="3.0" fill="#0000FF" />
+<path d="M 223.60,201.40 C 240.52,186.74 328.00,227.63 440.00,233.13" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 223.60,201.40 C 240.52,186.74 328.00,227.63 440.00,233.13" stroke="#000000" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<circle cx="223.6" cy="201.39999999999998" r="4.0" fill="white" />
+<circle cx="223.6" cy="201.39999999999998" r="3.0" fill="#000000" />
+<text x="490.0" y="208.13" font-size="10.0" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#333">SN65HVD230 CAN Transceiver</text>
+<rect x="450.0" y="213.13" width="80.0" height="60.0" rx="5" ry="5" fill="#95A5A6" stroke="#333" stroke-width="2" opacity="0.9" />
+<path d="M 440.00,223.13 L 457.00,223.13" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,223.13 L 457.00,223.13" stroke="#FF0000" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,253.13 L 457.00,253.13" stroke="#2C2C2C" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,253.13 L 457.00,253.13" stroke="#00FF00" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,243.13 L 457.00,243.13" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,243.13 L 457.00,243.13" stroke="#0000FF" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<path d="M 440.00,233.13 L 457.00,233.13" stroke="white" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="1.0" />
+<path d="M 440.00,233.13 L 457.00,233.13" stroke="#000000" stroke-width="3.0" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+<circle cx="455.0" cy="223.13" r="4.0" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="223.13" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
+<rect x="461.0" y="218.13" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="225.63" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">3V3</text>
+<circle cx="455.0" cy="233.13" r="4.0" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="233.13" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
+<rect x="461.0" y="228.13" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="235.63" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">GND</text>
+<circle cx="455.0" cy="243.13" r="4.0" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="243.13" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
+<rect x="461.0" y="238.13" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="245.63" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">CTX</text>
+<circle cx="455.0" cy="253.13" r="4.0" fill="white" opacity="0.8" />
+<circle cx="455.0" cy="253.13" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
+<rect x="461.0" y="248.13" width="21.5" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="465.0" y="255.63" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">CRX</text>
+<circle cx="525.0" cy="233.13" r="4.0" fill="white" opacity="0.8" />
+<circle cx="525.0" cy="233.13" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
+<rect x="493.0" y="228.13" width="26.0" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="497.0" y="235.63" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">CANH</text>
+<circle cx="525.0" cy="243.13" r="4.0" fill="white" opacity="0.8" />
+<circle cx="525.0" cy="243.13" r="3.0" fill="#FFD700" stroke="#333" stroke-width="1" opacity="1.0" />
+<rect x="493.0" y="238.13" width="26.0" height="10" rx="2" ry="2" fill="#000000" opacity="0.8" />
+<text x="497.0" y="245.63" font-size="7" text-anchor="start" font-family="Arial, sans-serif" fill="#FFFFFF">CANL</text>
+</svg>


### PR DESCRIPTION
## What
The ESP32-S3-DevKitC-1 board + SN65HVD230 CAN transceiver landed in #282 with an example config (`examples/esp32_s3_can_transceiver.yaml`), but the example itself was undocumented: no rendered image, no docs section, not in the examples index.

## Changes
- **Render** `images/esp32_s3_can_transceiver.svg` from the example config.
- **Document** it in `docs/guide/examples-esp.md` — new `## ESP32-S3 CAN (TWAI) via SN65HVD230` section matching the existing pattern (description → full YAML → generate cmd → result image → board aliases). Embedded YAML is byte-for-byte identical to the example file.
- **Index** update in `docs/guide/examples.md` ESP row.
- **List** it in `examples/README.md` under a new ESP32 subsection.

## Notes
- Docs/assets only — no code, no API/schema changes.
- Pin comments verified against the board config (pin 4 = GPIO43, pin 6 = GPIO44).
- `pinviz validate --strict` passes on the example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)