### PR TITLE
chore: gitignore local PR-review comparison artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ bad_wiring.yaml
 fixed_wiring.yaml
 fixed.svg
 /plans/
+
+# PR review comparison artifacts (local only)
+images/pr_review/


### PR DESCRIPTION
Adds `images/pr_review/` to `.gitignore`. That directory holds before/after render comparisons generated locally during PR review — not for commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)